### PR TITLE
Fix: Capitaize App Name Removed From Report Template

### DIFF
--- a/pebblo/reports/templates/reportTemplate.html
+++ b/pebblo/reports/templates/reportTemplate.html
@@ -15,7 +15,7 @@
       <div class="surface-60 inter font-48 font-thin">Data Report</div>
       <div class="mt-9">
         <div class="surface-60 inter font-48 font-thin break-word">
-          {{data.name|capitalize}}
+          {{data.name}}
         </div>
         <div class="purple-10 inter font-28 mt-2">
           {{data.framework.name|capitalize}} {{data.framework.version}}


### PR DESCRIPTION
- Capitalized app name is removed from report template.