### PR TITLE
Move test dependencies to project.optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,7 @@ dependencies = [
   "transformers==4.36.2",
   "jinja2>=3.1.3",
   "weasyprint==60.2",
-  "python-dateutil==2.8.2",
-  "httpx==0.26.0",
-  "pytest==8.0.0",
-  "pytest-mock==3.12.0"
+  "python-dateutil==2.8.2"
 ]
 
 # List additional groups of dependencies here (e.g. development
@@ -127,7 +124,7 @@ dependencies = [
 # projects.
 [project.optional-dependencies] # Optional
 dev = ["check-manifest"]
-test = ["coverage"]
+test = ["coverage", "httpx==0.26.0", "pytest==8.0.0", "pytest-mock==3.12.0"]
 
 # List URLs that are relevant to your project
 #


### PR DESCRIPTION
Move test dependencies to the `project.optional-dependencies`