### PR TITLE
Fixing entity classifier initialization issue.

### DIFF
--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -14,7 +14,7 @@ def start():
     # Init TopicClassifier(This step downloads the models and put in cache)
     _ = TopicClassifier()
     # Init EntityClassifier(This step downloads all necessary training models)
-    _ = EntityClassifier
+    _ = EntityClassifier()
 
     # CLI input details
     cli_input = list(sys.argv)

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -11,7 +11,6 @@ from pebblo.app.enums.enums import ReportConstants
 
 # Init topic classifier
 topic_classifier_obj = TopicClassifier()
-# Init topic classifier
 
 
 class DocHelper:


### PR DESCRIPTION
This is issue since we added this `EntityClassifier` initialization in daemon.py, but it was suppressed due to one more import in doc_helper.py at the top. Now we moved that import to inside class, so this is giving issue.
It was not caught in my testing in earlier PR as the model was already present in my venv.