### PR TITLE
Config.yaml Support for Pebblo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ pebblo
 
 Pebblo daemon now listens to `localhost:8000` to accept Gen-AI application data snippets for inspection and reporting.
 
+#### Pebblo Optional Flags
+
+- `--config <file>`: Specifies a custom configuration file in yaml format.
+
+```bash
+pebblo --config config.yaml
+````
+
 ## Pebblo Safe DataLoader for Langchain
 
 `Pebblo Safe DataLoader` currently supports Langchain framework.

--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -1,0 +1,70 @@
+import yaml
+
+from pydantic import BaseSettings, Field
+import pathlib
+
+# Default config value
+dir_path = pathlib.Path().absolute()
+
+
+# Port BaseModel
+class PortConfig(BaseSettings):
+    host: str = Field(default='localhost')
+    port: int = Field(default=8000)
+
+
+# Report BaseModel
+class ReportConfig(BaseSettings):
+    format: str = Field(default='pdf')
+    outputDir: str = Field(dir_path)
+
+
+# Logging BaseModel
+class LoggingConfig(BaseSettings):
+    level: str = Field(default='info')
+
+
+# ConfigFile BaseModel
+class Config(BaseSettings):
+    daemon:  PortConfig
+    reports: ReportConfig
+    logging: LoggingConfig
+
+
+def load_config(path) -> Config:
+    try:
+        # If Path does not exist in command, set default config value
+        conf_obj = Config(
+            daemon=PortConfig(
+                host='localhost',
+                port=8000
+            ),
+            reports=ReportConfig(
+                format='pdf',
+                outputDir='~./pebblo'
+            ),
+            logging=LoggingConfig(
+                level='info'
+            )
+        )
+        if not path:
+            # Setting Default config details
+            return conf_obj.dict()
+
+        # If Path exist, set config value
+        else:
+            con_file = path
+            try:
+                with open(con_file, "r") as output:
+                    cred_json = yaml.safe_load(output)
+                    parsed_config = Config.parse_obj(cred_json)
+                    config_dict = parsed_config.dict()
+                    return config_dict
+            except IOError as err:
+                print(f"no credentials file found at {con_file}")
+                return conf_obj.dict()
+
+    except Exception as err:
+        print(f'Error while loading config details, err: {err}')
+
+

--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -41,7 +41,7 @@ def load_config(path) -> Config:
             ),
             reports=ReportConfig(
                 format='pdf',
-                outputDir='~./pebblo'
+                outputDir='~/.pebblo'
             ),
             logging=LoggingConfig(
                 level='info'

--- a/pebblo/app/config/config.yaml
+++ b/pebblo/app/config/config.yaml
@@ -1,0 +1,8 @@
+daemon:
+  port: 8000
+  host: localhost
+logging:
+  level: info
+reports:
+  format: pdf
+  outputDir:  ~/.pebblo

--- a/pebblo/app/config/service.py
+++ b/pebblo/app/config/service.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+
+import uvicorn
+import asyncio
+from pebblo.app.routers.routers import router_instance
+
+
+class Service:
+    def __init__(self, config_details):
+        # Initialise app instance
+        self.app = FastAPI()
+        # Register the router instance with the main app
+        self.app.include_router(router_instance.router)
+        # Fetching Details from Config File
+        self.config_details = config_details
+        self.port = self.config_details.get('daemon', {}).get('port', 8000)
+        self.host = self.config_details.get('daemon', {}).get('host', '0.0.0.0')
+        self.log_level = self.config_details.get('logging', {}).get('level', 'info')
+
+    async def create_main_api_server(self):
+        # Add config Details to Uvicorn
+        config = uvicorn.Config(app=self.app, host=self.host, port=self.port, log_level=self.log_level)
+        server = uvicorn.Server(config)
+        await server.serve()
+
+    def start(self):
+        asyncio.run(self.create_main_api_server())
+
+
+

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -1,22 +1,30 @@
-import uvicorn
-from fastapi import FastAPI
-from pebblo.app.routers.routers import router_instance
+from pebblo.app.config.config import load_config
+import sys
+import os
+import argparse
 
-from pebblo.topic_classifier.topic_classifier import TopicClassifier
-from pebblo.entity_classifier.entity_classifier import EntityClassifier
+
+config_details = {}
 
 
 def start():
+    global config_details
+    # For loading config file details
+    parser = argparse.ArgumentParser(description="Pebblo  CLI")
+    parser.add_argument('--config', type=str, help="Config file path")
+    args = parser.parse_args()
+    path = args.config
+    config_details = load_config(path)
+
+    # LazyLoading TopicClassifier and EntityClassifier to avoid circular dependency
+    from pebblo.topic_classifier.topic_classifier import TopicClassifier
+    from pebblo.entity_classifier.entity_classifier import EntityClassifier
     # Init TopicClassifier(This step downloads the models and put in cache)
     _ = TopicClassifier()
     # Init EntityClassifier(This step downloads all necessary training models)
-    _ = EntityClassifier()
+    _ = EntityClassifier
 
-    # Initialise app instance
-    app = FastAPI()
-
-    # Register the router instance with the main app
-    app.include_router(router_instance.router)
-
-    # running local server
-    uvicorn.run(app, host="localhost", port=8000, log_level="info")
+    # Starting Uvicorn Service Using config details
+    from pebblo.app.config.service import Service
+    svc = Service(config_details)
+    svc.start()

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -1,6 +1,4 @@
 from pebblo.app.config.config import load_config
-import sys
-import os
 import argparse
 
 
@@ -22,7 +20,7 @@ def start():
     # Init TopicClassifier(This step downloads the models and put in cache)
     _ = TopicClassifier()
     # Init EntityClassifier(This step downloads all necessary training models)
-    _ = EntityClassifier
+    _ = EntityClassifier()
 
     # Starting Uvicorn Service Using config details
     from pebblo.app.config.service import Service

--- a/pebblo/app/enums/enums.py
+++ b/pebblo/app/enums/enums.py
@@ -2,6 +2,8 @@
 These are all enums related to Inspector.
 """
 from enum import Enum
+import os
+from pebblo.app.daemon import config_details
 
 
 class CacheDir(Enum):
@@ -9,7 +11,7 @@ class CacheDir(Enum):
     metadata_file_path = f"{metadata_folder}/metadata.json"
     report_file_name = "report.json"
     pdf_report_file_name = "pebblo_report.pdf"
-    home_dir = ".pebblo"
+    home_dir = config_details.get('reports', {}).get('outputDir', '~/.pebblo')
 
 
 class ReportConstants(Enum):

--- a/pebblo/app/libs/logger.py
+++ b/pebblo/app/libs/logger.py
@@ -2,16 +2,17 @@
 Module to handle logging functionality
 """
 import logging
-import os
+from pebblo.app.daemon import config_details
 
 
 def get_logger():
     """Get object of logger"""
+    logger_level = config_details.get('logging', {}).get('level', 'info').upper()
     logger_obj = logging.getLogger("Pebblo Logger")
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     console_handle = logging.StreamHandler()
     console_handle.setFormatter(formatter)
-    logger_obj.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
+    logger_obj.setLevel(logger_level)
     logger_obj.propagate = False
     if not logger_obj.handlers:
         logger_obj.addHandler(console_handle)

--- a/tests/app/test_daemon.py
+++ b/tests/app/test_daemon.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from pebblo.app.routers.routers import router_instance
+from pebblo.app import daemon
 
 app = FastAPI()
 app.include_router(router_instance.router)
@@ -15,20 +16,20 @@ client = TestClient(app)
 
 @pytest.fixture(scope="module")
 def mocked_objects():
-    with patch('pebblo.app.daemon.TopicClassifier') as topic_classifier, \
-            patch('pebblo.app.daemon.EntityClassifier') as entity_classifier:
+    with (patch.object(daemon, 'start', 'TopicClassifier') as topic_classifier,
+          patch.object(daemon, 'start', 'EntityClassifier') as entity_classifier):
         yield topic_classifier, entity_classifier
 
 
 @pytest.fixture(scope="module")
 def topic_classifier():
-    with patch('pebblo.app.daemon.TopicClassifier') as topic_classifier:
+    with patch.object(daemon, 'start', 'TopicClassifier') as topic_classifier:
         yield topic_classifier
 
 
 @pytest.fixture(scope="module")
 def entity_classifier():
-    with patch('pebblo.app.daemon.EntityClassifier') as entity_classifier:
+    with patch.object(daemon, 'start', 'EntityClassifier') as entity_classifier:
         yield entity_classifier
 
 


### PR DESCRIPTION
## The process involves loading configuration details and subsequently utilizing them to initiate a service and manage APIs effectively.

## Case1

#### Running pebblo without --config command

It will use default config details
```
Example:
(venv) PS C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo> pebblo                                                             
Microsoft Visual C++ Redistributable is not installed, this may lead to the DLL load failure.
                 It can be downloaded at https://aka.ms/vs/16/release/vc_redist.x64.exe
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\utils\generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pyt
ree_node instead.
  _torch_pytree._register_pytree_node(
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\utils\generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pyt
ree_node instead.
  _torch_pytree._register_pytree_node(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['pre_classifier.lora_B.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.
lora_A.default.weight', 'classifier.lora_A.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a B
ertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequence
Classification model).
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\pipelines\text_classification.py:105: UserWarning: `return_all_scores` is now deprecated,  if want a similar functionality use `top_k=N
one` instead of `return_all_scores=True` or `top_k=1` instead of `return_all_scores=False`.
  warnings.warn(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['pre_classifier.lora_B.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.
lora_A.default.weight', 'classifier.lora_A.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a B
ertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequence
Classification model).
INFO:     Started server process [2092]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)

It is running using default port which is 8000

```

## Case2

#### Running pebblo with --config details

```
config.yaml file
daemon:
  port: 5000
  host: 'localhost'
logging:
  level: info
reports:
  format: pdf
  outputDir:  ~/.pebblo
```



#### Running pebblo using conifg file port

```
(venv) PS C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo> pebblo --config C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo\pebblo\app\config\config.yaml                   
Microsoft Visual C++ Redistributable is not installed, this may lead to the DLL load failure.
                 It can be downloaded at https://aka.ms/vs/16/release/vc_redist.x64.exe
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\utils\generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pyt
ree_node instead.
  _torch_pytree._register_pytree_node(
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\utils\generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pyt
ree_node instead.
  _torch_pytree._register_pytree_node(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora
_B.default.weight', 'pre_classifier.lora_A.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a B
ertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequence
Classification model).
C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\venv\Lib\site-packages\transformers\pipelines\text_classification.py:105: UserWarning: `return_all_scores` is now deprecated,  if want a similar functionality use `top_k=N
one` instead of `return_all_scores=True` or `top_k=1` instead of `return_all_scores=False`.
  warnings.warn(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora
_B.default.weight', 'pre_classifier.lora_A.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a B
ertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequence
Classification model).
INFO:     Started server process [3952]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:5000 (Press CTRL+C to quit)

With config details it is running on port 5000
```

## --help

#### pebblo --help will give below output

```
(venv) PS C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo> pebblo --help                                                           
usage: pebblo [-h] [--config CONFIG]

Pebblo CLI

options:
  -h, --help       show this help message and exit
  --config CONFIG  Config file path

```

## Running pebblo with random command

```
(venv) PS C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo> pebblo --abc C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo\pebblo\app\config\config.yaml         
usage: pebblo [-h] [--config CONFIG]
pebblo: error: unrecognized arguments: --abc C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo\pebblo\app\config\config.yaml
```

```
(venv) PS C:\Users\KunalJadhav\Desktop\Kunal_Desktop\pebblo_6_2_24\pebblo> pebblo --hellllp                                                                                             
usage: pebblo [-h] [--config CONFIG]
pebblo: error: unrecognized arguments: --hellllp
```

