### PR TITLE
Update json mapping for load history 

### DIFF
--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -319,7 +319,7 @@ class LoaderHelper:
         # LoadHistory will be considered up to the specified load history limit.
         # if no of reports are greater than specified limit than, we provide the dir path for all reports
         load_history["history"] = list()
-        load_history["moreReportsPath"] = ""
+        load_history["moreReportsPath"] = "-"
         report_counts = len(load_ids)
         top_n_latest_loader_id = load_ids[-ReportConstants.loader_history_limit.value - 1:]
         top_n_latest_loader_id.reverse()

--- a/pebblo/reports/templates/reportTemplate.html
+++ b/pebblo/reports/templates/reportTemplate.html
@@ -141,7 +141,7 @@
           </div>
         </div>
         <div class="mt-2 inter surface-10-opacity font-11">
-          Find more reports on: {{ loadHistory.moreReportsPath }}
+          Find more reports on: {{ data.loadHistory.moreReportsPath }}
         </div>
 
         <div class="mt-12">


### PR DESCRIPTION
Fix for loadHistory not found in more reports path: Updated data mapping to {{ data.loadHistory.moreReportsPath }}