### PR TITLE
Skipped printing config details at the startup

### DIFF
--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -1,5 +1,4 @@
 import yaml
-from tqdm import tqdm
 
 from pydantic import BaseSettings, Field
 import pathlib
@@ -30,13 +29,6 @@ class Config(BaseSettings):
     reports: ReportConfig
     logging: LoggingConfig
 
-def print_config_output(config_output, p_bar=None):
-    if isinstance(p_bar, tqdm):
-        p_bar.write(config_output)
-    else:
-        print(config_output)
-
-
 def load_config(path, p_bar=None) -> Config:
     try:
         # If Path does not exist in command, set default config value
@@ -55,9 +47,6 @@ def load_config(path, p_bar=None) -> Config:
         )
         if not path:
             # Setting Default config details
-            config_details = f"Config values : {conf_obj.dict()}"
-            print_config_output(config_details, p_bar)
-
             return conf_obj.dict()
 
         # If Path exist, set config value
@@ -68,9 +57,6 @@ def load_config(path, p_bar=None) -> Config:
                     cred_json = yaml.safe_load(output)
                     parsed_config = Config.parse_obj(cred_json)
                     config_dict = parsed_config.dict()
-                    config_details = f"Config values : {config_dict}"
-                    print_config_output(config_details, p_bar)
-
                     return config_dict
             except IOError as err:
                 print(f"no credentials file found at {con_file}")


### PR DESCRIPTION
Output without custom config.yaml:
```
pebblo git:(shreyas-log-change) ✗ pebblo
Downloading topic, entity classifier models ...
Initializing topic classifier ...
Initializing topic classifier ... done
Initializing entity classifier ...
Initializing entity classifier ... done
Pebblo server starting ...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:13<00:00,  1.37s/it]
INFO:     Started server process [99401]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
INFO:     App Discover Request Processed Successfully
INFO:     ::1:56418 - "POST /v1/app/discover HTTP/1.1" 200 OK
INFO:     PDF report generated at : /Users/shreyasdamle/.pebblo/Shreyas14FebCsvLoaderApp001/pebblo_report.pdf
INFO:     Loader Doc request Request processed successfully.
INFO:     ::1:56419 - "POST /v1/loader/doc HTTP/1.1" 200 OK
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [99401]
Pebblo server Stopped. BYE!
```

Output with custom config.yaml:
```
 pebblo git:(shreyas-log-change) ✗ pebblo --config pebblo/app/config/config.yaml
Downloading topic, entity classifier models ...
Initializing topic classifier ...
Initializing topic classifier ... done
Initializing entity classifier ...
Initializing entity classifier ... done
Pebblo server starting ...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:02<00:00,  3.89it/s]
INFO:     Started server process [99531]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
DEBUG:    AI_APP [Shreyas14FebCsvLoaderApp001]: Input Data: {'name': 'Shreyas14FebCsvLoaderApp001', 'owner': 'Shreyas Damle', 'description': '', 'load_id': '33c94af7-8559-4b6c-bdd3-9f23db74cbd0', 'runtime': {'type': 'desktop', 'host': 'OPLPT012.local', 'path': '/Users/shreyasdamle/work/cloud_defense/rag_apps/openginie_csv', 'ip': '127.0.0.1', 'platform': 'macOS-14.3.1-arm64-arm-64bit', 'os': 'Darwin', 'os_version': 'Darwin Kernel Version 23.3.0: Wed Dec 20 21:33:31 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T8112', 'language': 'python', 'language_version': '3.11.7', 'runtime': 'Mac OSX'}, 'framework': {'name': 'langchain', 'version': '0.1.23'}, 'plugin_version': '0.1.0'}
DEBUG:    JSON data written successfully to: /Users/shreyasdamle/.pebblo/Shreyas14FebCsvLoaderApp001//metadata/metadata.json
DEBUG:    AI_APPS [Shreyas14FebCsvLoaderApp001]: Instance Details: {'type': 'desktop', 'host': 'OPLPT012.local', 'path': '/Users/shreyasdamle/work/cloud_defense/rag_apps/openginie_csv', 'runtime': 'Mac OSX', 'ip': '127.0.0.1', 'language': 'python', 'languageVersion': '3.11.7', 'platform': 'macOS-14.3.1-arm64-arm-64bit', 'os': 'Darwin', 'osVersion': 'Darwin Kernel Version 23.3.0: Wed Dec 20 21:33:31 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T8112', 'createdAt': datetime.datetime(2024, 2, 15, 11, 47, 33, 855440)}
DEBUG:    Final Output For Discovery Call: {'metadata': {'createdAt': datetime.datetime(2024, 2, 15, 11, 47, 36, 986001), 'modifiedAt': datetime.datetime(2024, 2, 15, 11, 47, 36, 986001)}, 'name': 'Shreyas14FebCsvLoaderApp001', 'description': '', 'owner': 'Shreyas Damle', 'pluginVersion': '0.1.0', 'instanceDetails': {'type': 'desktop', 'host': 'OPLPT012.local', 'path': '/Users/shreyasdamle/work/cloud_defense/rag_apps/openginie_csv', 'runtime': 'Mac OSX', 'ip': '127.0.0.1', 'language': 'python', 'languageVersion': '3.11.7', 'platform': 'macOS-14.3.1-arm64-arm-64bit', 'os': 'Darwin', 'osVersion': 'Darwin Kernel Version 23.3.0: Wed Dec 20 21:33:31 PST 2023; root:xnu-10002.81.5~7/RELEASE_ARM64_T8112', 'createdAt': datetime.datetime(2024, 2, 15, 11, 47, 33, 855440)}, 'framework': {'name': 'langchain', 'version': '0.1.23'}, 'lastUsed': datetime.datetime(2024, 2, 15, 11, 47, 36, 985998)}
DEBUG:    JSON data written successfully to: /Users/shreyasdamle/.pebblo/Shreyas14FebCsvLoaderApp001/33c94af7-8559-4b6c-bdd3-9f23db74cbd0//metadata/metadata.json
INFO:     App Discover Request Processed Successfully
INFO:     ::1:56478 - "POST /v1/app/discover HTTP/1.1" 200 OK
```