### PR TITLE
Download and Install the Spacy model package as a part of the Pebblo install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dependencies = [
   "tqdm",
   "xhtml2pdf==0.2.15",
   "weasyprint==60.2",
+  "en-core-web-lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.7.1/en_core_web_lg-3.7.1-py3-none-any.whl"
 ]
 
 # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
**Description:**
Download and Install the Spacy model package as a part of the Pebblo install


**Source of GitHub link:** 
The GitHub link used for installing is taken from the Spacy package that is installed with the Pebblo using the following command:
```
spacy info en_core_web_lg --url
```

**Testing:**
Tried building & installing Pebblo on my local. It shows the download step.

<img width="1229" alt="spacy-model-download" src="https://github.com/daxa-ai/pebblo/assets/17705063/4b2e7a08-49dc-4596-80ef-6e7f12dda857">


Reference: [Spacy Docs](https://spacy.io/usage/models#download-pip)
