### PR TITLE
Resolve ruff lint errors

### DIFF
--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -61,7 +61,7 @@ def load_config(path) -> Config:
                     config_dict = parsed_config.dict()
                     return config_dict
             except IOError as err:
-                print(f"no credentials file found at {con_file}")
+                print(f"no credentials file found at {con_file}. Error : {err}")
                 return conf_obj.dict()
 
     except Exception as err:

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -1,5 +1,4 @@
 from contextlib import redirect_stderr, redirect_stdout
-import uvicorn
 
 from io import StringIO
 from tqdm import tqdm

--- a/pebblo/app/enums/enums.py
+++ b/pebblo/app/enums/enums.py
@@ -2,7 +2,6 @@
 These are all enums related to Inspector.
 """
 from enum import Enum
-import os
 from pebblo.app.daemon import config_details
 
 

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -124,7 +124,7 @@ class AppDiscover:
                          f"/{CacheDir.metadata_file_path.value}")
             self._write_file_content_to_path(ai_apps.dict(), file_path)
 
-            logger.debug(f"AiApp discovery request completed successfully")
+            logger.debug("AiApp discovery request completed successfully")
             return {"message": "App Discover Request Processed Successfully"}
         except ValidationError as ex:
             logger.error(f"Error in process_request. Error:{ex}")

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -1,6 +1,4 @@
-import logging
 from datetime import datetime
-
 from fastapi import HTTPException
 from pydantic import ValidationError
 

--- a/pebblo/reports/reports.py
+++ b/pebblo/reports/reports.py
@@ -1,6 +1,6 @@
 # Import HTML to PDF generator function
 
-from pebblo.reports.html_to_pdf_generator.report_generator import convertHtmlToPdf;
+from pebblo.reports.html_to_pdf_generator.report_generator import convertHtmlToPdf
 from pebblo.reports.enums.report_libraries import ReportLibraries, template_renderer_mapping
 from pebblo.reports.libs.logger import logger
 import os

--- a/samples/langchain/acme-corp-rag/acme_corp_rag.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag.py
@@ -21,7 +21,7 @@ class AcmeCorpRAG:
 
         # Load documents
 
-        print(f"Loading RAG documents ...")
+        print("Loading RAG documents ...")
         self.loader = CSVLoader(self.file_path)
         self.documents = self.loader.load()
         self.filtered_docs = filter_complex_metadata(self.documents)
@@ -29,9 +29,9 @@ class AcmeCorpRAG:
 
         # Load documents into VectorDB
 
-        print(f"Hydrating Vector DB ...")
+        print("Hydrating Vector DB ...")
         self.vectordb = self.embeddings(self.filtered_docs)
-        print(f"Finished hydrating Vector DB ...\n")
+        print("Finished hydrating Vector DB ...\n")
 
         # Prepare retriever QA chain
 

--- a/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
@@ -22,7 +22,7 @@ class AcmeCorpRAG:
 
         # Load documents
 
-        print(f"Loading RAG documents ...")
+        print("Loading RAG documents ...")
         self.loader = PebbloSafeLoader(
             CSVLoader(self.file_path),
             name="acme-corp-rag-1", # App name (Mandatory)
@@ -35,9 +35,9 @@ class AcmeCorpRAG:
 
         # Load documents into VectorDB
 
-        print(f"Hydrating Vector DB ...")
+        print("Hydrating Vector DB ...")
         self.vectordb = self.embeddings(self.filtered_docs)
-        print(f"Finished hydrating Vector DB ...\n")
+        print("Finished hydrating Vector DB ...\n")
 
         # Prepare retriever QA chain
 

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -1,8 +1,8 @@
 import datetime
 import pytest
 from unittest.mock import MagicMock, patch
-from pebblo.app.models.models import Summary, DataSource
-from pebblo.app.service.doc_helper import LoaderHelper, AiDataModel
+from pebblo.app.models.models import DataSource
+from pebblo.app.service.doc_helper import LoaderHelper
 
 data = {
     "name": "UnitTestApp",


### PR DESCRIPTION
- Removed unused imports.
- Added `err` to exception message.
- Removed unnccessary `;`