### PR TITLE
Install Spacy and Spacy model package as a part of the Pebblo install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ dependencies = [
   "fastapi==0.109.0",
   "uvicorn==0.25.0",
   "pydantic==1.10.8",
+  "spacy>=3.7.2, <3.8.0",
   "presidio-analyzer==2.2.351",
   "presidio-anonymizer==2.2.351",
   "torch>=2.1.2",
@@ -116,6 +117,7 @@ dependencies = [
   "tqdm",
   "xhtml2pdf==0.2.15",
   "weasyprint==60.2",
+  "en-core-web-lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.7.1/en_core_web_lg-3.7.1-py3-none-any.whl",
 ]
 
 # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
**Description:**
Install the Spacy and Spacy model package as a part of the Pebblo install.
- Spacy model package(`en_core_web_lg-3.7.1`)
- Spacy(`>=3.7.2, <3.8.0`) Source: [en_core_web_lg-3.7.1 release docs](https://github.com/explosion/spacy-models/releases/tag/en_core_web_lg-3.7.1).
- Presidio version(2.2.351 ) support for spacy versions (spacy <4.0.0,>=3.4.4).  Source: [Presidio code](https://github.com/microsoft/presidio/blob/main/presidio-analyzer/setup.py#L37). The chosen spacy version range lies within the supported range.



**Source of GitHub link:** 
The GitHub link used for installing is taken from the Spacy package that is installed with the Pebblo using the following command:
```
spacy info en_core_web_lg --url
```
Reference: [Spacy Docs](https://spacy.io/usage/models#download-pip)



**Testing:**
Tried building & installing Pebblo on my local. It shows the download step.

<img width="1232" alt="Screenshot 2024-02-20 at 2 48 28 PM" src="https://github.com/daxa-ai/pebblo/assets/17705063/4a89c94b-d97c-45b0-beb9-fa94a2d65b08">


