### PR TITLE
Updating scores for entity classifier for context matching

### DIFF
--- a/pebblo/entity_classifier/entity_classifier.py
+++ b/pebblo/entity_classifier/entity_classifier.py
@@ -93,10 +93,10 @@ class EntityClassifier:
                 registry=custom_registry,
                 context_aware_enhancer=LemmaContextAwareEnhancer(
                     context_similarity_factor=float(
-                        ConfidenceScore.ContextSimilarityScore.value
+                        ConfidenceScore.EntityContextSimilarityFactor.value
                     ),
                     min_score_with_context_similarity=float(
-                        ConfidenceScore.Entity.value
+                        ConfidenceScore.EntityMinScoreWithContext.value
                     ),
                 ),
             )

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -41,5 +41,7 @@ class SecretEntities(Enum):
 class ConfidenceScore(Enum):
     Entity = "0.8"  # It denotes the
     EntityMinScore = "0.45"  # It denotes the pattern's strength
-    EntityContextSimilarityFactor = "0.35"  # It denotes how much to enhance confidence of match entity
+    EntityContextSimilarityFactor = (
+        "0.35"  # It denotes how much to enhance confidence of match entity
+    )
     EntityMinScoreWithContext = "0.4"  # It denotes minimum confidence score

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -39,6 +39,7 @@ class SecretEntities(Enum):
 
 
 class ConfidenceScore(Enum):
-    Entity = "0.35"  # It denotes minimum confidence score when context matches
-    EntityMinScore = "0.4"  # It denotes the pattern's strength
-    ContextSimilarityScore = "0.3"  # It denotes how much to enhance confidence of match entity when context matches
+    Entity = "0.8"  # It denotes the
+    EntityMinScore = "0.45"  # It denotes the pattern's strength
+    EntityContextSimilarityFactor = "0.35"  # It denotes how much to enhance confidence of match entity
+    EntityMinScoreWithContext = "0.4"  # It denotes minimum confidence score

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -39,7 +39,7 @@ class SecretEntities(Enum):
 
 
 class ConfidenceScore(Enum):
-    Entity = "0.8"  # It denotes the
+    Entity = "0.8"  # based on this score entity output is finalized
     EntityMinScore = "0.45"  # It denotes the pattern's strength
     EntityContextSimilarityFactor = (
         "0.35"  # It denotes how much to enhance confidence of match entity


### PR DESCRIPTION
Updated following scores while context matching:

- Entity = "0.8"  # based on this score entity output is finalized.
- EntityMinScore = "0.45"  # It denotes the pattern's strength
- EntityContextSimilarityFactor = "0.35"  # It denotes how much to enhance confidence of match entity
- EntityMinScoreWithContext = "0.4"  # It denotes minimum confidence score