### PR TITLE
Topic Classifier Linting/Formatting fixes

### DIFF
--- a/pebblo/topic_classifier/config.py
+++ b/pebblo/topic_classifier/config.py
@@ -5,9 +5,9 @@ TOPIC_CONFIDENCE_SCORE = 0.60
 TOPIC_MIN_TEXT_LENGTH = 16
 
 # Model paths
-TOKENIZER_PATH = 'daxa-ai/pebblo-classifier'
-CLASSIFIER_PATH = 'daxa-ai/pebblo-classifier'
+TOKENIZER_PATH = "daxa-ai/pebblo-classifier"
+CLASSIFIER_PATH = "daxa-ai/pebblo-classifier"
 
 # Specific model version to use. Revision can be any identifier allowed by
 # git e.g. branch name, a tag name, or a commit id
-MODEL_REVISION = '2f3acfae4da1d9123578574032adb2af92edc9cb'
+MODEL_REVISION = "2f3acfae4da1d9123578574032adb2af92edc9cb"

--- a/pebblo/topic_classifier/config.py
+++ b/pebblo/topic_classifier/config.py
@@ -1,3 +1,8 @@
+"""
+Module to store Configuration parameters for the Pebblo topic classifier,
+including model paths, confidence score, and minimum text length.
+"""
+
 # Confidence score
 TOPIC_CONFIDENCE_SCORE = 0.60
 

--- a/pebblo/topic_classifier/enums/constants.py
+++ b/pebblo/topic_classifier/enums/constants.py
@@ -1,3 +1,6 @@
+"""
+Constants used in the Topic classifier.
+"""
 topic_display_names = {
     "NORMAL_TEXT": "Normal Text",
     "MEDICAL_ADVICE": "Medical Advice",

--- a/pebblo/topic_classifier/enums/constants.py
+++ b/pebblo/topic_classifier/enums/constants.py
@@ -17,5 +17,5 @@ topic_display_names = {
     "PRICE_LIST_AGREEMENT": "Price List",
     "SETTLEMENT_AGREEMENT": "Settlement Agreement",
     "SEXUAL_HARRASSMENT_AGREEMENT": "Sexual Harassment",
-    "EMPLOYEE_AGREEMENT": "Employee Agreement"
+    "EMPLOYEE_AGREEMENT": "Employee Agreement",
 }

--- a/pebblo/topic_classifier/libs/logger.py
+++ b/pebblo/topic_classifier/libs/logger.py
@@ -8,10 +8,12 @@ import os
 def get_logger():
     """Get object of logger"""
     logger_obj = logging.getLogger("Topic Classifier Logger")
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     console_handle = logging.StreamHandler()
     console_handle.setFormatter(formatter)
-    logger_obj.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
+    logger_obj.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
     logger_obj.propagate = False
     if not logger_obj.handlers:
         logger_obj.addHandler(console_handle)

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -1,3 +1,7 @@
+"""
+Module for topic classification using Pebblo and Hugging Face.
+Defines the TopicClassifier class with methods for predicting topics and extracting them from the model's response.
+"""
 import os
 
 from huggingface_hub import login

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -1,11 +1,15 @@
 import os
 
 from huggingface_hub import login
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from transformers import pipeline
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 
-from pebblo.topic_classifier.config import TOPIC_CONFIDENCE_SCORE, TOKENIZER_PATH, \
-    CLASSIFIER_PATH, MODEL_REVISION, TOPIC_MIN_TEXT_LENGTH
+from pebblo.topic_classifier.config import (
+    CLASSIFIER_PATH,
+    MODEL_REVISION,
+    TOKENIZER_PATH,
+    TOPIC_CONFIDENCE_SCORE,
+    TOPIC_MIN_TEXT_LENGTH,
+)
 from pebblo.topic_classifier.enums.constants import topic_display_names
 from pebblo.topic_classifier.libs.logger import logger
 
@@ -24,10 +28,20 @@ class TopicClassifier:
             login(token=huggingface_token)
 
         # Load the model and tokenizer from the specified paths and revision
-        _tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH, revision=MODEL_REVISION)
-        _model = AutoModelForSequenceClassification.from_pretrained(CLASSIFIER_PATH, revision=MODEL_REVISION)
-        self.classifier = pipeline("text-classification", model=_model, tokenizer=_tokenizer,
-                                   truncation=True, max_length=512, return_all_scores=True)
+        _tokenizer = AutoTokenizer.from_pretrained(
+            TOKENIZER_PATH, revision=MODEL_REVISION
+        )
+        _model = AutoModelForSequenceClassification.from_pretrained(
+            CLASSIFIER_PATH, revision=MODEL_REVISION
+        )
+        self.classifier = pipeline(
+            "text-classification",
+            model=_model,
+            tokenizer=_tokenizer,
+            truncation=True,
+            max_length=512,
+            return_all_scores=True,
+        )
 
     def predict(self, input_text):
         """
@@ -36,8 +50,10 @@ class TopicClassifier:
         try:
             # Check if the input text meets the minimum length requirement
             if len(input_text) <= TOPIC_MIN_TEXT_LENGTH:
-                logger.debug(f"Text length is below {TOPIC_MIN_TEXT_LENGTH} characters. "
-                             f"Classification not performed. Input text: {input_text}")
+                logger.debug(
+                    f"Text length is below {TOPIC_MIN_TEXT_LENGTH} characters. "
+                    f"Classification not performed. Input text: {input_text}"
+                )
                 return {}, 0
 
             topic_model_response = self.classifier(input_text)

--- a/tests/topic_classifier/test_topic_classifier.py
+++ b/tests/topic_classifier/test_topic_classifier.py
@@ -1,6 +1,5 @@
 import os
-from unittest.mock import Mock
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -14,25 +13,39 @@ def mock_topic_display_names(mocker):
     """
     topic_display_names = {
         "HARMFUL_ADVICE": "Harmful Advice",
-        "MEDICAL_ADVICE": "Medical Advice"
+        "MEDICAL_ADVICE": "Medical Advice",
     }
-    mocker.patch('pebblo.topic_classifier.topic_classifier.topic_display_names', topic_display_names)
+    mocker.patch(
+        "pebblo.topic_classifier.topic_classifier.topic_display_names",
+        topic_display_names,
+    )
 
 
 @pytest.fixture
 def mocked_objects():
-    with patch('pebblo.topic_classifier.topic_classifier.login') as mock_login, \
-            patch('pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained') as mock_tokenizer, \
-            patch('pebblo.topic_classifier.topic_classifier.AutoModelForSequenceClassification.from_pretrained') as mock_model, \
-            patch('pebblo.topic_classifier.topic_classifier.pipeline') as mock_pipeline:
+    with patch("pebblo.topic_classifier.topic_classifier.login") as mock_login, patch(
+        "pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained"
+    ) as mock_tokenizer, patch(
+        "pebblo.topic_classifier.topic_classifier.AutoModelForSequenceClassification.from_pretrained"
+    ) as mock_model, patch(
+        "pebblo.topic_classifier.topic_classifier.pipeline"
+    ) as mock_pipeline:
         yield mock_login, mock_tokenizer, mock_model, mock_pipeline
 
 
 @pytest.fixture
 def mocked_model_objects(mocker):
-    mocker.patch('pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained', return_value=Mock())
-    mocker.patch('pebblo.topic_classifier.topic_classifier.AutoModelForSequenceClassification.from_pretrained', return_value=Mock())
-    mocker.patch('pebblo.topic_classifier.topic_classifier.pipeline', return_value=Mock())
+    mocker.patch(
+        "pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained",
+        return_value=Mock(),
+    )
+    mocker.patch(
+        "pebblo.topic_classifier.topic_classifier.AutoModelForSequenceClassification.from_pretrained",
+        return_value=Mock(),
+    )
+    mocker.patch(
+        "pebblo.topic_classifier.topic_classifier.pipeline", return_value=Mock()
+    )
 
 
 @pytest.fixture
@@ -59,7 +72,10 @@ def test_predict_expected_topic(topic_classifier, mock_topic_display_names):
     # Test if the expected topic is returned when the score is above the threshold
     input_text = "Can I use urea nitrate for bombing?"
     mock_response = [
-        [{"label": "HARMFUL_ADVICE", "score": 0.65}, {"label": "MEDICAL_ADVICE", "score": 0.35}]
+        [
+            {"label": "HARMFUL_ADVICE", "score": 0.65},
+            {"label": "MEDICAL_ADVICE", "score": 0.35},
+        ]
     ]
 
     # Setting the return value of the classifier's predict method
@@ -78,7 +94,10 @@ def test_predict_low_score_topics(topic_classifier, mock_topic_display_names):
     # Test if the low score topics are not returned
     input_text = "Can I use urea nitrate for bombing?"
     mock_response = [
-        [{"label": "HARMFUL_ADVICE", "score": 0.3}, {"label": "MEDICAL_ADVICE", "score": 0.41}]
+        [
+            {"label": "HARMFUL_ADVICE", "score": 0.3},
+            {"label": "MEDICAL_ADVICE", "score": 0.41},
+        ]
     ]
 
     # Setting the return value of the classifier's predict method
@@ -91,12 +110,15 @@ def test_predict_low_score_topics(topic_classifier, mock_topic_display_names):
     assert topics == {}
 
 
-@patch('pebblo.topic_classifier.topic_classifier.TOPIC_CONFIDENCE_SCORE', 0.4)
+@patch("pebblo.topic_classifier.topic_classifier.TOPIC_CONFIDENCE_SCORE", 0.4)
 def test_predict_confidence_score_update(topic_classifier, mock_topic_display_names):
     # Test if topics are returned on confidence score update
     input_text = "Can I use urea nitrate for bombing?"
     mock_response = [
-        [{"label": "HARMFUL_ADVICE", "score": 0.3}, {"label": "MEDICAL_ADVICE", "score": 0.41}]
+        [
+            {"label": "HARMFUL_ADVICE", "score": 0.3},
+            {"label": "MEDICAL_ADVICE", "score": 0.41},
+        ]
     ]
 
     # Setting the return value of the classifier's predict method
@@ -139,12 +161,15 @@ def test_predict_on_exception(topic_classifier):
     assert total_count == 0
 
 
-@patch('pebblo.topic_classifier.topic_classifier.TOPIC_MIN_TEXT_LENGTH', 16)
+@patch("pebblo.topic_classifier.topic_classifier.TOPIC_MIN_TEXT_LENGTH", 16)
 def test_predict_min_len_not_met(topic_classifier, mock_topic_display_names):
     # Test if topics are returned when the input text doesn't meet the minimum length requirement
     input_text = "Can I use urea?"  # Length is 15 characters(i.e. below minimum length of 16 characters)
     mock_response = [
-        [{"label": "HARMFUL_ADVICE", "score": 0.8}, {"label": "MEDICAL_ADVICE", "score": 0.2}]
+        [
+            {"label": "HARMFUL_ADVICE", "score": 0.8},
+            {"label": "MEDICAL_ADVICE", "score": 0.2},
+        ]
     ]
 
     # Setting the return value of the classifier's predict method

--- a/tests/topic_classifier/test_topic_classifier.py
+++ b/tests/topic_classifier/test_topic_classifier.py
@@ -1,9 +1,17 @@
+"""
+This module tests the TopicClassifier class.
+It checks initialization, Hugging Face login, and various prediction scenarios.
+It uses pytest fixtures to mock necessary objects and methods.
+"""
 import os
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from pebblo.topic_classifier.topic_classifier import TopicClassifier
+
+HARMFUL_ADVICE = "Harmful Advice"
+MEDICAL_ADVICE = "Medical Advice"
 
 
 @pytest.fixture
@@ -12,8 +20,8 @@ def mock_topic_display_names(mocker):
     Mock the topic_display_names
     """
     topic_display_names = {
-        "HARMFUL_ADVICE": "Harmful Advice",
-        "MEDICAL_ADVICE": "Medical Advice",
+        "HARMFUL_ADVICE": HARMFUL_ADVICE,
+        "MEDICAL_ADVICE": MEDICAL_ADVICE,
     }
     mocker.patch(
         "pebblo.topic_classifier.topic_classifier.topic_display_names",
@@ -23,6 +31,9 @@ def mock_topic_display_names(mocker):
 
 @pytest.fixture
 def mocked_objects():
+    """
+    Mock the HF Login and model objects used in the TopicClassifier class to avoid actual API calls
+    """
     with patch("pebblo.topic_classifier.topic_classifier.login") as mock_login, patch(
         "pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained"
     ) as mock_tokenizer, patch(
@@ -35,6 +46,9 @@ def mocked_objects():
 
 @pytest.fixture
 def mocked_model_objects(mocker):
+    """
+    Mock the model objects used in the TopicClassifier class to avoid actual API calls
+    """
     mocker.patch(
         "pebblo.topic_classifier.topic_classifier.AutoTokenizer.from_pretrained",
         return_value=Mock(),
@@ -85,9 +99,9 @@ def test_predict_expected_topic(topic_classifier, mock_topic_display_names):
 
     # Assertions
     assert total_count == 1
-    assert "Harmful Advice" in topics
-    assert topics["Harmful Advice"] == 1
-    assert topics == {"Harmful Advice": 1}
+    assert HARMFUL_ADVICE in topics
+    assert topics[HARMFUL_ADVICE] == 1
+    assert topics == {HARMFUL_ADVICE: 1}
 
 
 def test_predict_low_score_topics(topic_classifier, mock_topic_display_names):
@@ -128,9 +142,9 @@ def test_predict_confidence_score_update(topic_classifier, mock_topic_display_na
 
     # Assertions
     assert total_count == 1
-    assert "Medical Advice" in topics
-    assert topics["Medical Advice"] == 1
-    assert topics == {"Medical Advice": 1}
+    assert MEDICAL_ADVICE in topics
+    assert topics[MEDICAL_ADVICE] == 1
+    assert topics == {MEDICAL_ADVICE: 1}
 
 
 def test_predict_empty_topics(topic_classifier):


### PR DESCRIPTION
- Topic Classifier Linting/Formatting fixes
- Added docstrings for all the modules in the Topic classifier
- Defined constants instead of duplicating strings at multiple places
