### PR TITLE
Ruff formatting fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ lint:
 	ruff check .
 	ruff format . --diff
 	ruff --select I .
-	mkdir -p $(MYPY_CACHE) && mypy --install-types --non-interactive $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
+	mkdir -p $(MYPY_CACHE) && mypy --install-types --non-interactive $(PYTHON_FILES) --cache-dir $(MYPY_CACHE) --exclude build/
 
 spell_check:
 	codespell --toml pyproject.toml

--- a/pebblo/app/api/api.py
+++ b/pebblo/app/api/api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
-from pebblo.app.service.service import AppLoaderDoc
+
 from pebblo.app.service.discovery_service import AppDiscover
+from pebblo.app.service.service import AppLoaderDoc
 
 
 class App:

--- a/pebblo/app/api/local_ui_api.py
+++ b/pebblo/app/api/local_ui_api.py
@@ -1,11 +1,12 @@
 from pathlib import Path
-from fastapi import APIRouter, Request
-from fastapi.templating import Jinja2Templates
-from fastapi.responses import FileResponse
-from pebblo.app.service.local_ui_service import AppData
-from pebblo.app.enums.enums import CacheDir
-from pebblo.app.utils.utils import get_full_path
 
+from fastapi import APIRouter, Request
+from fastapi.responses import FileResponse
+from fastapi.templating import Jinja2Templates
+
+from pebblo.app.enums.enums import CacheDir
+from pebblo.app.service.local_ui_service import AppData
+from pebblo.app.utils.utils import get_full_path
 
 templates = Jinja2Templates(
     directory=Path(__file__).parent.parent.absolute() / "pebblo-ui"

--- a/pebblo/app/api/redirection_api.py
+++ b/pebblo/app/api/redirection_api.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+
 from pebblo.app.enums.enums import CacheDir
 
 

--- a/pebblo/app/api/redirection_api.py
+++ b/pebblo/app/api/redirection_api.py
@@ -12,4 +12,4 @@ class App:
 
     @staticmethod
     def redirect():
-        return f"{CacheDir.proxy.value}/pebblo/"
+        return f"{CacheDir.PROXY.value}/pebblo/"

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -1,9 +1,10 @@
-import os
-from pebblo.app.utils.utils import get_full_path
-from pebblo.app.libs.logger import logger
-from abc import ABC, abstractmethod
-import sys
 import logging
+import os
+import sys
+from abc import ABC, abstractmethod
+
+from pebblo.app.libs.logger import logger
+from pebblo.app.utils.utils import get_full_path
 
 
 class ConfigValidator(ABC):

--- a/pebblo/app/config/service.py
+++ b/pebblo/app/config/service.py
@@ -1,14 +1,15 @@
+import asyncio
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
-from typing import Any
 from pathlib import Path
-import asyncio
+from typing import Any
+
+import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
-import uvicorn
+
 from pebblo.app.routers.local_ui_routers import local_ui_router_instance
 from pebblo.app.routers.redirection_router import redirect_router_instance
-
 
 with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
     from pebblo.app.routers.routers import router_instance

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -1,6 +1,7 @@
 """
 This is entry point for Pebblo(Pebblo Server and Local UI)
 """
+
 from contextlib import redirect_stderr, redirect_stdout
 import argparse
 from io import StringIO

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -2,12 +2,13 @@
 This is entry point for Pebblo(Pebblo Server and Local UI)
 """
 
-from contextlib import redirect_stderr, redirect_stdout
 import argparse
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
-from tqdm import tqdm
-from pebblo.app.config.config import load_config
 
+from tqdm import tqdm
+
+from pebblo.app.config.config import load_config
 
 config_details = {}
 
@@ -31,8 +32,8 @@ def classifier_init(p_bar):
     """Initialize topic and entity classifier."""
     p_bar.write("Downloading topic, entity classifier models ...")
     with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        from pebblo.topic_classifier.topic_classifier import TopicClassifier
         from pebblo.entity_classifier.entity_classifier import EntityClassifier
+        from pebblo.topic_classifier.topic_classifier import TopicClassifier
     p_bar.update(3)
     p_bar.write("Initializing topic classifier ...")
     p_bar.update(1)

--- a/pebblo/app/enums/enums.py
+++ b/pebblo/app/enums/enums.py
@@ -1,6 +1,7 @@
 """
 These are all enums related to Pebblo Server.
 """
+
 from enum import Enum
 
 from pebblo.app.daemon import config_details

--- a/pebblo/app/libs/logger.py
+++ b/pebblo/app/libs/logger.py
@@ -1,6 +1,7 @@
 """
 Module to handle logging functionality
 """
+
 import logging
 
 

--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, Field
-from typing import Optional, List, Union
 from datetime import datetime
+from typing import List, Optional, Union
 from uuid import UUID
+
+from pydantic import BaseModel, Field
 
 
 class Metadata(BaseModel):

--- a/pebblo/app/routers/local_ui_routers.py
+++ b/pebblo/app/routers/local_ui_routers.py
@@ -1,5 +1,6 @@
+from fastapi.responses import FileResponse, HTMLResponse
+
 from pebblo.app.api.local_ui_api import App
-from fastapi.responses import HTMLResponse, FileResponse
 
 # Create an instance of APp with a specific prefix
 local_ui_router_instance = App(prefix="/pebblo")

--- a/pebblo/app/routers/redirection_router.py
+++ b/pebblo/app/routers/redirection_router.py
@@ -1,5 +1,6 @@
-from pebblo.app.api.redirection_api import App
 from fastapi.responses import RedirectResponse
+
+from pebblo.app.api.redirection_api import App
 
 # Create an instance of APp with a specific prefix
 redirect_router_instance = App()

--- a/pebblo/app/routers/redirection_router.py
+++ b/pebblo/app/routers/redirection_router.py
@@ -6,6 +6,5 @@ redirect_router_instance = App()
 
 # Add routes to the class-based router
 redirect_router_instance.router.add_api_route(
-    "/", App.redirect , methods=["GET"], response_class=RedirectResponse
+    "/", App.redirect, methods=["GET"], response_class=RedirectResponse
 )
- 

--- a/pebblo/app/routers/routers.py
+++ b/pebblo/app/routers/routers.py
@@ -1,6 +1,7 @@
 """
 Routes for Pebblo Server
 """
+
 from pebblo.app.api.api import App
 
 # Create an instance of APp with a specific prefix

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -33,7 +33,7 @@ class AppDiscover:
         metadata = Metadata(createdAt=datetime.now(), modifiedAt=datetime.now())
         ai_apps_model = AiApp(
             metadata=metadata,
-            name=self.data.get("name", ""),
+            name=self.data.get("name"),
             description=self.data.get("description", "-"),
             owner=self.data.get("owner", ""),
             pluginVersion=self.data.get("plugin_version"),

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -33,9 +33,9 @@ class AppDiscover:
         metadata = Metadata(createdAt=datetime.now(), modifiedAt=datetime.now())
         ai_apps_model = AiApp(
             metadata=metadata,
-            name=self.data.get("name"),
+            name=self.data.get("name", ""),
             description=self.data.get("description", "-"),
-            owner=self.data.get("owner"),
+            owner=self.data.get("owner", ""),
             pluginVersion=self.data.get("plugin_version"),
             instanceDetails=instance_details,
             framework=self.data.get("framework"),

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -1,6 +1,7 @@
 """
 This module handles app discovery business logic.
 """
+
 from datetime import datetime
 from pydantic import ValidationError
 from fastapi import HTTPException
@@ -14,6 +15,7 @@ class AppDiscover:
     """
     This class handles app discovery business logic.
     """
+
     def __init__(self, data: dict):
         self.data = data
         self.load_id = data.get("load_id")

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -3,12 +3,14 @@ This module handles app discovery business logic.
 """
 
 from datetime import datetime
-from pydantic import ValidationError
+
 from fastapi import HTTPException
+from pydantic import ValidationError
+
 from pebblo.app.enums.enums import CacheDir
-from pebblo.app.utils.utils import write_json_to_file, read_json_file
 from pebblo.app.libs.logger import logger
-from pebblo.app.models.models import Metadata, AiApp, InstanceDetails
+from pebblo.app.models.models import AiApp, InstanceDetails, Metadata
+from pebblo.app.utils.utils import read_json_file, write_json_to_file
 
 
 class AppDiscover:

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -110,7 +110,6 @@ class LoaderHelper:
         loader_details = self.data.get("loader_details", {})
         last_used = datetime.now()
         doc_model = AiDocs(
-            appId=self.load_id,
             doc=doc_info.data,
             sourceSize=doc.get("source_path_size", 0),
             fileOwner=doc.get("file_owner", "-"),
@@ -375,7 +374,7 @@ class LoaderHelper:
         Retrieve previous runs details and create load history and return
         """
         logger.debug("Fetching previous execution details and creating loader history")
-        load_history = {}
+        load_history = dict()
         # Reading metadata file & get load details
         app_name = self.data.get("name")
         current_load_id = self.load_id

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -1,6 +1,7 @@
 """
-    Doc helper module for loader doc related task
+Doc helper module for loader doc related task
 """
+
 import ast
 import os.path
 from datetime import datetime
@@ -254,9 +255,9 @@ class LoaderHelper:
                     )
                 unique_snippets_set.add(source_path)
                 data_source_findings[label_name]["fileCount"] = len(unique_snippets_set)
-                data_source_findings[label_name][
-                    "unique_snippets"
-                ] = unique_snippets_set
+                data_source_findings[label_name]["unique_snippets"] = (
+                    unique_snippets_set
+                )
 
                 #  If the snippet count exceeds the snippet limit,
                 #  we will refrain from adding the snippet to the snippet list

--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -4,16 +4,17 @@ This module handles business logic for local UI
 
 import json
 import os
+
 from pebblo.app.enums.enums import CacheDir
 from pebblo.app.libs.logger import logger
+from pebblo.app.models.models import AppListDetails, AppModel
 from pebblo.app.utils.utils import (
+    get_document_with_findings_data,
     get_full_path,
     read_json_file,
-    update_findings_summary,
     update_data_source,
-    get_document_with_findings_data,
+    update_findings_summary,
 )
-from pebblo.app.models.models import AppListDetails, AppModel
 
 
 class AppData:

--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -1,6 +1,7 @@
 """
 This module handles business logic for local UI
 """
+
 import json
 import os
 from pebblo.app.enums.enums import CacheDir
@@ -19,6 +20,7 @@ class AppData:
     """
     This class handles business logic for local UI
     """
+
     @staticmethod
     def get_all_apps_details():
         """
@@ -47,8 +49,10 @@ class AppData:
                         logger.debug(f"Skipping hidden folder {app_dir}")
                         continue
                     # Path to metadata.json
-                    app_path = (f"{CacheDir.HOME_DIR.value}/{app_dir}/"
-                                f"{CacheDir.METADATA_FILE_PATH.value}")
+                    app_path = (
+                        f"{CacheDir.HOME_DIR.value}/{app_dir}/"
+                        f"{CacheDir.METADATA_FILE_PATH.value}"
+                    )
                     logger.debug(f"metadata.json path {app_path}")
                     app_json = read_json_file(app_path)
 
@@ -63,8 +67,10 @@ class AppData:
                     # Fetch latest loadId
                     latest_load_id = app_json.get("load_ids")[-1]
 
-                    app_detail_path = (f"{CacheDir.HOME_DIR.value}/{app_dir}/"
-                                       f"{latest_load_id}/{CacheDir.REPORT_DATA_FILE_NAME.value}")
+                    app_detail_path = (
+                        f"{CacheDir.HOME_DIR.value}/{app_dir}/"
+                        f"{latest_load_id}/{CacheDir.REPORT_DATA_FILE_NAME.value}"
+                    )
                     logger.debug(f"report.json path {app_detail_path}")
                     app_detail_json = read_json_file(app_detail_path)
 
@@ -116,7 +122,8 @@ class AppData:
                     # Fetch document with findings details from app metadata.json file
                     app_metadata_detail_path = (
                         f"{CacheDir.HOME_DIR.value}/{app_dir}/"
-                        f"{latest_load_id}/{CacheDir.METADATA_FILE_PATH.value}")
+                        f"{latest_load_id}/{CacheDir.METADATA_FILE_PATH.value}"
+                    )
                     app_metadata_json_details = read_json_file(app_metadata_detail_path)
 
                     # Fetch required data for DocumentWithFindings
@@ -179,8 +186,10 @@ class AppData:
             latest_load_id = app_json.get("load_ids")[-1]
 
             # Path to report.json
-            app_detail_path = (f"{CacheDir.HOME_DIR.value}/{app_dir}/"
-                               f"{latest_load_id}/{CacheDir.REPORT_DATA_FILE_NAME.value}")
+            app_detail_path = (
+                f"{CacheDir.HOME_DIR.value}/{app_dir}/"
+                f"{latest_load_id}/{CacheDir.REPORT_DATA_FILE_NAME.value}"
+            )
             logger.debug(f"metadata.json path {app_detail_path}")
 
             # Read app details from report.json

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -1,6 +1,7 @@
 """
 This module handles app loader/doc API business logic.
 """
+
 from datetime import datetime
 
 from fastapi import HTTPException
@@ -18,6 +19,7 @@ class AppLoaderDoc:
     """
     This class handles app loader/doc API business logic.
     """
+
     def __init__(self, data):
         self.data = data
         self.app_name = self.data.get("name")
@@ -117,8 +119,10 @@ class AppLoaderDoc:
             )
 
             # Read metadata file & get current load details
-            app_metadata_file_path = (f"{CacheDir.HOME_DIR.value}/{self.app_name}/"
-                                      f"{CacheDir.METADATA_FILE_PATH.value}")
+            app_metadata_file_path = (
+                f"{CacheDir.HOME_DIR.value}/{self.app_name}/"
+                f"{CacheDir.METADATA_FILE_PATH.value}"
+            )
             app_metadata = read_json_file(app_metadata_file_path)
             if not app_metadata:
                 return {
@@ -140,7 +144,7 @@ class AppLoaderDoc:
                 )
                 return {
                     "Message": f"Could not read metadata file at "
-                               f"{app_load_metadata_file_path}. Exiting"
+                    f"{app_load_metadata_file_path}. Exiting"
                 }
 
             # Add/Update Loader Details with input loader details

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -7,12 +7,12 @@ from datetime import datetime
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from pebblo.reports.reports import Reports
 from pebblo.app.enums.enums import CacheDir
-from pebblo.app.utils.utils import write_json_to_file, read_json_file, get_full_path
 from pebblo.app.libs.logger import logger
 from pebblo.app.models.models import LoaderMetadata
 from pebblo.app.service.doc_helper import LoaderHelper
+from pebblo.app.utils.utils import get_full_path, read_json_file, write_json_to_file
+from pebblo.reports.reports import Reports
 
 
 class AppLoaderDoc:

--- a/pebblo/app/utils/utils.py
+++ b/pebblo/app/utils/utils.py
@@ -1,6 +1,7 @@
 import json
-from os import makedirs, path, getcwd
 from json import JSONEncoder, dump
+from os import getcwd, makedirs, path
+
 from pebblo.app.libs.logger import logger
 
 

--- a/pebblo/app/utils/utils.py
+++ b/pebblo/app/utils/utils.py
@@ -24,9 +24,7 @@ def write_json_to_file(data, file_path):
         dir_path = path.dirname(full_file_path)
         makedirs(dir_path, exist_ok=True)
         with open(full_file_path, "w") as metadata_file:
-            dump(
-                data, metadata_file, indent=4, cls=DatetimeEncoder
-            )
+            dump(data, metadata_file, indent=4, cls=DatetimeEncoder)
             logger.debug(f"JSON data written successfully to: {full_file_path}")
     except Exception as e:
         logger.error(f"Error writing JSON data to file: {e}")

--- a/pebblo/entity_classifier/libs/logger.py
+++ b/pebblo/entity_classifier/libs/logger.py
@@ -1,6 +1,7 @@
 """
 Module to handle logging functionality
 """
+
 import logging
 import os
 

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -1,6 +1,7 @@
 """
 Copyright (c) 2024 Cloud Defense, Inc. All rights reserved.
 """
+
 from enum import Enum
 
 secret_entities_context_mapping = {

--- a/pebblo/entity_classifier/utils/utils.py
+++ b/pebblo/entity_classifier/utils/utils.py
@@ -1,6 +1,7 @@
 """
 Copyright (c) 2024 Cloud Defense, Inc. All rights reserved.
 """
+
 from presidio_analyzer import Pattern, PatternRecognizer, RecognizerRegistry
 
 from pebblo.entity_classifier.utils.config import (

--- a/pebblo/reports/html_to_pdf_generator/generator_functions.py
+++ b/pebblo/reports/html_to_pdf_generator/generator_functions.py
@@ -3,7 +3,8 @@ Defines functions to generate PDF from HTML for respective renderers
 """
 
 import os
-from weasyprint import HTML, CSS
+
+from weasyprint import CSS, HTML
 from xhtml2pdf import pisa
 
 

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -2,9 +2,11 @@
 Report generator and supporting functions
 """
 
-from decimal import Decimal
 import datetime
+from decimal import Decimal
+
 import jinja2
+
 from pebblo.reports.enums.report_libraries import library_function_mapping
 
 

--- a/pebblo/reports/reports.py
+++ b/pebblo/reports/reports.py
@@ -5,11 +5,12 @@ Contains generate_report() to generate report pdf
 # Import HTML to PDF generator function
 
 import os
-from pebblo.reports.html_to_pdf_generator.report_generator import convert_html_to_pdf
+
 from pebblo.reports.enums.report_libraries import (
     ReportLibraries,
     template_renderer_mapping,
 )
+from pebblo.reports.html_to_pdf_generator.report_generator import convert_html_to_pdf
 from pebblo.reports.libs.logger import logger
 
 

--- a/pebblo/topic_classifier/enums/constants.py
+++ b/pebblo/topic_classifier/enums/constants.py
@@ -1,6 +1,7 @@
 """
 Constants used in the Topic classifier.
 """
+
 topic_display_names = {
     "NORMAL_TEXT": "Normal Text",
     "MEDICAL_ADVICE": "Medical Advice",

--- a/pebblo/topic_classifier/libs/logger.py
+++ b/pebblo/topic_classifier/libs/logger.py
@@ -1,6 +1,7 @@
 """
 Module to handle logging functionality
 """
+
 import logging
 import os
 

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -2,6 +2,7 @@
 Module for topic classification using Pebblo and Hugging Face.
 Defines the TopicClassifier class with methods for predicting topics and extracting them from the model's response.
 """
+
 import os
 
 from huggingface_hub import login

--- a/samples/langchain/acme-corp-rag/acme_corp_rag.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag.py
@@ -1,17 +1,15 @@
-from langchain.chains import RetrievalQA
-from langchain.document_loaders.csv_loader import CSVLoader
-from langchain_openai.embeddings import OpenAIEmbeddings
-from langchain_openai.llms import OpenAI
-from langchain.schema import Document
-from langchain_community.vectorstores import Chroma
-from langchain_community.vectorstores.utils import filter_complex_metadata
 from typing import List
-
 
 # Fill-in OPENAI_API_KEY in .env file
 # in this directory before proceeding
-
 from dotenv import load_dotenv
+from langchain.chains import RetrievalQA
+from langchain.document_loaders.csv_loader import CSVLoader
+from langchain.schema import Document
+from langchain_community.vectorstores import Chroma
+from langchain_community.vectorstores.utils import filter_complex_metadata
+from langchain_openai.embeddings import OpenAIEmbeddings
+from langchain_openai.llms import OpenAI
 
 load_dotenv()
 

--- a/samples/langchain/acme-corp-rag/acme_corp_rag.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag.py
@@ -12,7 +12,9 @@ from typing import List
 # in this directory before proceeding
 
 from dotenv import load_dotenv
+
 load_dotenv()
+
 
 class AcmeCorpRAG:
     def __init__(self, file_path: str):
@@ -40,7 +42,7 @@ class AcmeCorpRAG:
             llm=llm,
             chain_type="stuff",
             retriever=self.vectordb.as_retriever(),
-            verbose=True
+            verbose=True,
         )
 
     @staticmethod

--- a/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
@@ -1,18 +1,16 @@
-from langchain.chains import RetrievalQA
-from langchain.document_loaders.csv_loader import CSVLoader
-from langchain_openai.embeddings import OpenAIEmbeddings
-from langchain_openai.llms import OpenAI
-from langchain.schema import Document
-from langchain_community.vectorstores import Chroma
-from langchain_community.vectorstores.utils import filter_complex_metadata
 from typing import List
-
-from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 
 # Fill-in OPENAI_API_KEY in .env file
 # in this directory before proceeding
-
 from dotenv import load_dotenv
+from langchain.chains import RetrievalQA
+from langchain.document_loaders.csv_loader import CSVLoader
+from langchain.schema import Document
+from langchain_community.document_loaders.pebblo import PebbloSafeLoader
+from langchain_community.vectorstores import Chroma
+from langchain_community.vectorstores.utils import filter_complex_metadata
+from langchain_openai.embeddings import OpenAIEmbeddings
+from langchain_openai.llms import OpenAI
 
 load_dotenv()
 

--- a/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
+++ b/samples/langchain/acme-corp-rag/acme_corp_rag_pebblo.py
@@ -13,7 +13,9 @@ from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 # in this directory before proceeding
 
 from dotenv import load_dotenv
+
 load_dotenv()
+
 
 class AcmeCorpRAG:
     def __init__(self, file_path: str):
@@ -25,9 +27,9 @@ class AcmeCorpRAG:
         print("Loading RAG documents ...")
         self.loader = PebbloSafeLoader(
             CSVLoader(self.file_path),
-            name="acme-corp-rag-1", # App name (Mandatory)
-            owner="Joe Smith",      # Owner (Optional)
-            description="Support productivity RAG application", # Description (Optional)
+            name="acme-corp-rag-1",  # App name (Mandatory)
+            owner="Joe Smith",  # Owner (Optional)
+            description="Support productivity RAG application",  # Description (Optional)
         )
         self.documents = self.loader.load()
         self.filtered_docs = filter_complex_metadata(self.documents)
@@ -46,7 +48,7 @@ class AcmeCorpRAG:
             llm=llm,
             chain_type="stuff",
             retriever=self.vectordb.as_retriever(),
-            verbose=True
+            verbose=True,
         )
 
     @staticmethod

--- a/tests/app/config/test_config_validation.py
+++ b/tests/app/config/test_config_validation.py
@@ -92,7 +92,11 @@ def test_reports_config_validate(setup_and_teardown):
     ]
 
     # Test with invalid renderer
-    config = {"format": "pdf", "renderer": "invalid_renderer", "outputDir": "~/.pebblo_test_"}
+    config = {
+        "format": "pdf",
+        "renderer": "invalid_renderer",
+        "outputDir": "~/.pebblo_test_",
+    }
     validator = ReportsConfig(config)
     validator.validate()
     assert validator.errors == [

--- a/tests/app/config/test_config_validation.py
+++ b/tests/app/config/test_config_validation.py
@@ -1,12 +1,14 @@
+import os
+import shutil
+
+import pytest
+
 from pebblo.app.config.config_validation import (
-    validate_config,
     DaemonConfig,
     LoggingConfig,
     ReportsConfig,
+    validate_config,
 )
-import pytest
-import os
-import shutil
 
 
 @pytest.fixture

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -1,6 +1,8 @@
 import datetime
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from pebblo.app.models.models import DataSource
 from pebblo.app.service.doc_helper import LoaderHelper
 

--- a/tests/app/test_daemon.py
+++ b/tests/app/test_daemon.py
@@ -1,12 +1,11 @@
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from pebblo.app.routers.routers import router_instance
 from pebblo.app import daemon
+from pebblo.app.routers.routers import router_instance
 
 app = FastAPI()
 app.include_router(router_instance.router)

--- a/tests/integration/samples/pebblo_csv_loader/pebblo_csvloader.py
+++ b/tests/integration/samples/pebblo_csv_loader/pebblo_csvloader.py
@@ -6,10 +6,10 @@ from langchain.chains import RetrievalQA
 from langchain.document_loaders.csv_loader import CSVLoader
 from langchain.schema import Document
 from langchain.vectorstores.utils import filter_complex_metadata
+from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores import Chroma
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
-from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 
 load_dotenv()
 logging.basicConfig(level=10)

--- a/tests/integration/samples/pebblo_csv_loader/pebblo_csvloader.py
+++ b/tests/integration/samples/pebblo_csv_loader/pebblo_csvloader.py
@@ -18,8 +18,10 @@ logging.basicConfig(level=10)
 class OpenAIGenieCsv:
     def __init__(self, file_path: str):
         self.loader = PebbloSafeLoader(
-            CSVLoader(file_path), "Pebblo_Automation_Testing_CSVLoader", "Pebblo Automation",
-            "CSV Loader Working as expected"
+            CSVLoader(file_path),
+            "Pebblo_Automation_Testing_CSVLoader",
+            "Pebblo Automation",
+            "CSV Loader Working as expected",
         )
         self.documents = self.loader.load()
         self.filtered_docs = filter_complex_metadata(self.documents)
@@ -29,7 +31,7 @@ class OpenAIGenieCsv:
             llm=llm,
             chain_type="stuff",
             retriever=self.vectordb.as_retriever(),
-            verbose=True
+            verbose=True,
         )
 
     @staticmethod

--- a/tests/topic_classifier/test_topic_classifier.py
+++ b/tests/topic_classifier/test_topic_classifier.py
@@ -3,6 +3,7 @@ This module tests the TopicClassifier class.
 It checks initialization, Hugging Face login, and various prediction scenarios.
 It uses pytest fixtures to mock necessary objects and methods.
 """
+
 import os
 from unittest.mock import MagicMock, Mock, patch
 


### PR DESCRIPTION
- Ruff formatting fixed.
- Ruff import warnings fixed.
- Mypy partial fix.
mypy was giving below error 
`pebblo/__init__.py: error: Duplicate module named "pebblo" (also at "./build/lib/pebblo/__init__.py")`, so skipped `build` dir from mypy.