### PR TITLE
Added timezone to date strings in report pdf

### DIFF
--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -6,11 +6,12 @@ from decimal import Decimal
 import datetime
 import jinja2
 from pebblo.reports.enums.report_libraries import library_function_mapping
+import time
 
 
 def date_formatter(date_obj):
     """Converts date string to object and returns formatted string for date (D M Y, H:M)"""
-    return date_obj.strftime("%d %B %Y , %H:%M")
+    return date_obj.strftime("%d %B %Y , %H:%M") + " " + time.localtime().tm_zone
 
 
 def get_file_size(size):
@@ -31,9 +32,12 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
     template_loader = jinja2.FileSystemLoader(searchpath=search_path)
     template_env = jinja2.Environment(loader=template_loader)
     template = template_env.get_template(template_name)
+    current_date = (
+        datetime.datetime.now().strftime("%B %d, %Y") + " " + time.localtime().tm_zone
+    )
     source_html = template.render(
         data=data,
-        date=datetime.datetime.now(),
+        date=current_date,
         datastores=data["dataSources"][0],
         findingDetails=data["dataSources"][0]["findingsDetails"],
         loadHistoryItemsToDisplay=data["loadHistory"]["history"],

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -27,7 +27,7 @@
           Application Owner: {{ data.reportSummary.owner }}
         </div>
         <div class="purple-10 font-13 inter font-thin mt-2">
-          Report Generated On {{ date.strftime('%B %d, %Y') }}
+          Report Generated On {{ date }}
         </div>
       </div>
     </section>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -616,7 +616,7 @@
             Application Owner: {{ data.reportSummary.owner }}
           </div>
           <div class="surface-10 font-13 inter font-thin mt-2">
-            Report Generated On {{ date.strftime('%B %d, %Y') }}
+            Report Generated On {{ date }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Added current timezone to all date strings in report pdf

Example:
<img width="523" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/919f7324-56db-4f97-9fa4-236e78b5e317">
