### PR TITLE
Update download url for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pebblo has two components.
 
 
 ```bash
-pip install pebblo
+pip install pebblo --extra-index-url https://packages.daxa.ai/simple/
 ```
 
 ### Run Pebblo Server


### PR DESCRIPTION
- changes related to scarf.sh 
- updated the readme to use --extra-index-url https://packages.daxa.ai/simple/ for pip install pebblo