### PR TITLE
Authorized Identity - backend changes to show authorized identities

### DIFF
--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -42,7 +42,7 @@ class AiDocs(BaseModel):
     entities: Optional[dict]
     topicCount: Optional[int]
     topics: Optional[dict]
-
+    authorizedIdentities: list
 
 class FrameworkInfo(BaseModel):
     name: Optional[str]
@@ -94,12 +94,14 @@ class TopFindings(BaseModel):
     findingsEntities: int
     findingsTopics: int
     findings: int
+    authorizedIdentities: list
 
 
 class Snippets(BaseModel):
     snippet: str
     sourcePath: str
     fileOwner: str
+    authorizedIdentities: list
 
 
 class DataSource(BaseModel):

--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -44,6 +44,7 @@ class AiDocs(BaseModel):
     topics: Optional[dict]
     authorizedIdentities: list
 
+
 class FrameworkInfo(BaseModel):
     name: Optional[str]
     version: Optional[str]

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -138,8 +138,7 @@ class LoaderHelper:
         loader_source_snippets = raw_data["loader_source_snippets"]
         top_n_findings_list = sorted(
             loader_source_snippets.items(), key=lambda x: x[1]["findings"], reverse=True
-        )
-        # [: ReportConstants.TOP_FINDINGS_LIMIT.value] Removed Limit of n findings
+        )[: ReportConstants.TOP_FINDINGS_LIMIT.value]
         top_n_findings = [
             {
                 "fileName": key,
@@ -222,6 +221,7 @@ class LoaderHelper:
                     "findings_entities": value["findings_entities"],
                     "findings_topics": value["findings_topics"],
                     "findings": value["findings"],
+                    "authorized_identities": value["authorized_identities"]
                 }
                 for key, value in loader_source_snippets.items()
             ]

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -125,6 +125,7 @@ class LoaderHelper:
             entities=doc_info.entities,
             topicCount=doc_info.topicCount,
             topics=doc_info.topics,
+            authorizedIdentities=doc.get("authorized_identities", [])
         )
         return doc_model.dict()
 
@@ -137,7 +138,8 @@ class LoaderHelper:
         loader_source_snippets = raw_data["loader_source_snippets"]
         top_n_findings_list = sorted(
             loader_source_snippets.items(), key=lambda x: x[1]["findings"], reverse=True
-        )[: ReportConstants.TOP_FINDINGS_LIMIT.value]
+        )
+        # [: ReportConstants.TOP_FINDINGS_LIMIT.value] Removed Limit of n findings
         top_n_findings = [
             {
                 "fileName": key,
@@ -150,6 +152,7 @@ class LoaderHelper:
                 "findingsEntities": value["findings_entities"],
                 "findingsTopics": value["findings_topics"],
                 "findings": value["findings"],
+                "authorizedIdentities": value["authorized_identities"]
             }
             for key, value in top_n_findings_list
         ]
@@ -239,6 +242,7 @@ class LoaderHelper:
             snippet=doc["doc"],
             sourcePath=source_path,
             fileOwner=doc.get("fileOwner", "-"),
+            authorizedIdentities=doc.get("authorizedIdentities", [])
         )
         for label_name, value in doc[entity_type].items():
             if label_name in data_source_findings.keys():
@@ -483,6 +487,7 @@ class LoaderHelper:
                 "findings_entities": doc["entityCount"],
                 "findings_topics": doc["topicCount"],
                 "findings": findings,
+                "authorized_identities": doc["authorizedIdentities"]
             }
             findings_entities += doc["entityCount"]
             findings_topics += doc["topicCount"]

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -125,7 +125,7 @@ class LoaderHelper:
             entities=doc_info.entities,
             topicCount=doc_info.topicCount,
             topics=doc_info.topics,
-            authorizedIdentities=doc.get("authorized_identities", [])
+            authorizedIdentities=doc.get("authorized_identities", []),
         )
         return doc_model.dict()
 
@@ -151,7 +151,7 @@ class LoaderHelper:
                 "findingsEntities": value["findings_entities"],
                 "findingsTopics": value["findings_topics"],
                 "findings": value["findings"],
-                "authorizedIdentities": value["authorized_identities"]
+                "authorizedIdentities": value["authorized_identities"],
             }
             for key, value in top_n_findings_list
         ]
@@ -221,7 +221,7 @@ class LoaderHelper:
                     "findings_entities": value["findings_entities"],
                     "findings_topics": value["findings_topics"],
                     "findings": value["findings"],
-                    "authorized_identities": value["authorized_identities"]
+                    "authorized_identities": value["authorized_identities"],
                 }
                 for key, value in loader_source_snippets.items()
             ]
@@ -242,7 +242,7 @@ class LoaderHelper:
             snippet=doc["doc"],
             sourcePath=source_path,
             fileOwner=doc.get("fileOwner", "-"),
-            authorizedIdentities=doc.get("authorizedIdentities", [])
+            authorizedIdentities=doc.get("authorizedIdentities", []),
         )
         for label_name, value in doc[entity_type].items():
             if label_name in data_source_findings.keys():
@@ -487,7 +487,7 @@ class LoaderHelper:
                 "findings_entities": doc["entityCount"],
                 "findings_topics": doc["topicCount"],
                 "findings": findings,
-                "authorized_identities": doc["authorizedIdentities"]
+                "authorized_identities": doc["authorizedIdentities"],
             }
             findings_entities += doc["entityCount"]
             findings_topics += doc["topicCount"]

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -151,7 +151,7 @@ class LoaderHelper:
                 "findingsEntities": value["findings_entities"],
                 "findingsTopics": value["findings_topics"],
                 "findings": value["findings"],
-                "authorizedIdentities": value["authorized_identities"],
+                "authorizedIdentities": value.get("authorized_identities", []),
             }
             for key, value in top_n_findings_list
         ]
@@ -221,7 +221,7 @@ class LoaderHelper:
                     "findings_entities": value["findings_entities"],
                     "findings_topics": value["findings_topics"],
                     "findings": value["findings"],
-                    "authorized_identities": value["authorized_identities"],
+                    "authorized_identities": value.get("authorized_identities", []),
                 }
                 for key, value in loader_source_snippets.items()
             ]

--- a/pebblo/app/utils/utils.py
+++ b/pebblo/app/utils/utils.py
@@ -181,6 +181,9 @@ def get_document_with_findings_data(data):
                             "findingsTopics": source_file_details.get(
                                 "findings_topics", 0
                             ),  # Get findings topics
+                            "authorizedIdentities": source_file_details.get(
+                                "authorized_identities", []
+                            ),  # Get authorized identities
                             "lastModified": loader_data.get(
                                 "lastModified"
                             ),  # Get the last modified timestamp

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -16,6 +16,7 @@ data = {
             "last_modified": datetime.datetime.now(),
             "file_owner": "FileOwner",
             "source_path_size": 1000,
+            "authorizedIdentities": []
         }
     ],
     "plugin_version": "0.1.0",
@@ -109,6 +110,7 @@ def test_get_doc_report_metadata(loader_helper):
         "fileOwner": "fileOwner",
         "sourceSize": 1000,
         "sourcePath": "/home/ubuntu/sens_data.csv",
+        "authorizedIdentities": []
     }
 
     output = loader_helper._get_doc_report_metadata(doc, raw_data)
@@ -120,6 +122,7 @@ def test_get_doc_report_metadata(loader_helper):
         "data_source_snippets": [],
         "loader_source_snippets": {
             "/home/ubuntu/sens_data.csv": {
+                'authorized_identities': [],
                 "findings_entities": 2,
                 "findings_topics": 1,
                 "findings": 3,
@@ -139,6 +142,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
+                        'authorizedIdentities': [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -154,6 +158,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
+                        'authorizedIdentities': [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -169,6 +174,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
+                        'authorizedIdentities': [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -213,6 +219,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
+                    'authorizedIdentities': [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -228,6 +235,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
+                    'authorizedIdentities': [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -243,6 +251,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
+                    'authorizedIdentities': [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -313,6 +322,7 @@ def test_update_app_details(loader_helper):
                         "findings_entities": 2,
                         "findings_topics": 1,
                         "findings": 3,
+                        "authorized_identities": []
                     }
                 ],
             }
@@ -369,6 +379,7 @@ def test_get_top_n_findings(loader_helper):
             "findingsEntities": 2,
             "findingsTopics": 1,
             "findings": 3,
+            "authorizedIdentities": []
         }
     ]
 

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -16,7 +16,7 @@ data = {
             "last_modified": datetime.datetime.now(),
             "file_owner": "FileOwner",
             "source_path_size": 1000,
-            "authorizedIdentities": []
+            "authorizedIdentities": [],
         }
     ],
     "plugin_version": "0.1.0",
@@ -110,7 +110,7 @@ def test_get_doc_report_metadata(loader_helper):
         "fileOwner": "fileOwner",
         "sourceSize": 1000,
         "sourcePath": "/home/ubuntu/sens_data.csv",
-        "authorizedIdentities": []
+        "authorizedIdentities": [],
     }
 
     output = loader_helper._get_doc_report_metadata(doc, raw_data)
@@ -122,7 +122,7 @@ def test_get_doc_report_metadata(loader_helper):
         "data_source_snippets": [],
         "loader_source_snippets": {
             "/home/ubuntu/sens_data.csv": {
-                'authorized_identities': [],
+                "authorized_identities": [],
                 "findings_entities": 2,
                 "findings_topics": 1,
                 "findings": 3,
@@ -142,7 +142,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
-                        'authorizedIdentities': [],
+                        "authorizedIdentities": [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -158,7 +158,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
-                        'authorizedIdentities': [],
+                        "authorizedIdentities": [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -174,7 +174,7 @@ def test_get_doc_report_metadata(loader_helper):
                 "unique_snippets": {"/home/ubuntu/sens_data.csv"},
                 "snippets": [
                     {
-                        'authorizedIdentities': [],
+                        "authorizedIdentities": [],
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -219,7 +219,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
-                    'authorizedIdentities': [],
+                    "authorizedIdentities": [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -235,7 +235,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
-                    'authorizedIdentities': [],
+                    "authorizedIdentities": [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -251,7 +251,7 @@ def test_get_finding_details(loader_helper):
             "unique_snippets": {"/home/ubuntu/sens_data.csv"},
             "snippets": [
                 {
-                    'authorizedIdentities': [],
+                    "authorizedIdentities": [],
                     "snippet": "Sample Doc",
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
@@ -322,7 +322,7 @@ def test_update_app_details(loader_helper):
                         "findings_entities": 2,
                         "findings_topics": 1,
                         "findings": 3,
-                        "authorized_identities": []
+                        "authorized_identities": [],
                     }
                 ],
             }
@@ -379,7 +379,7 @@ def test_get_top_n_findings(loader_helper):
             "findingsEntities": 2,
             "findingsTopics": 1,
             "findings": 3,
-            "authorizedIdentities": []
+            "authorizedIdentities": [],
         }
     ]
 


### PR DESCRIPTION
- These changes add authorized identities in documents with findings section per file and in snippet section per snippet.
- These changes are for local UI as well as for pdf report.

Testing:
- Tested locally and verified that authorized_entities are getting added in top findings and snippets.
- Need to be tested with Local UI after UI changes are done.