### PR TITLE
Log and print statement were not working in topic classfiier

### DIFF
--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -6,6 +6,10 @@ import argparse
 from tqdm import tqdm
 
 from pebblo.app.config.config import load_config
+import warnings
+
+warnings.filterwarnings("ignore", category=UserWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 config_details = {}
 

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -3,9 +3,7 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 """
 
 import argparse
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
-
+import sys
 from tqdm import tqdm
 
 from pebblo.app.config.config import load_config
@@ -31,26 +29,25 @@ def start():
 def classifier_init(p_bar):
     """Initialize topic and entity classifier."""
     p_bar.write("Downloading topic, entity classifier models ...")
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        from pebblo.entity_classifier.entity_classifier import EntityClassifier
-        from pebblo.topic_classifier.topic_classifier import TopicClassifier
+    from pebblo.entity_classifier.entity_classifier import EntityClassifier
+    from pebblo.topic_classifier.topic_classifier import TopicClassifier
     p_bar.update(3)
     p_bar.write("Initializing topic classifier ...")
     p_bar.update(1)
 
     # Init TopicClassifier(This step downloads the models and put in cache)
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        _ = TopicClassifier()
+    _ = TopicClassifier()
     p_bar.write("Initializing topic classifier ... done")
     p_bar.update(1)
+    
 
     p_bar.write("Initializing entity classifier ...")
     p_bar.update(1)
-
+    
     # Init EntityClassifier(This step downloads all necessary training models)
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        _ = EntityClassifier()
+    _ = EntityClassifier()
     p_bar.write("Initializing entity classifier ... done")
+
     p_bar.update(1)
 
 
@@ -59,7 +56,6 @@ def server_start(config: dict, p_bar: tqdm):
     p_bar.write("Pebblo server starting ...")
     # Starting Uvicorn Service Using config details
     from pebblo.app.config.service import Service
-
     p_bar.update(1)
     svc = Service(config_details=config)
     p_bar.update(2)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -4,6 +4,8 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 
 import argparse
 import warnings
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 
 from tqdm import tqdm
 
@@ -33,7 +35,8 @@ def start():
 def classifier_init(p_bar):
     """Initialize topic and entity classifier."""
     p_bar.write("Downloading topic, entity classifier models ...")
-    from pebblo.entity_classifier.entity_classifier import EntityClassifier
+    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+        from pebblo.entity_classifier.entity_classifier import EntityClassifier
     from pebblo.topic_classifier.topic_classifier import TopicClassifier
 
     p_bar.update(3)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -3,10 +3,11 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 """
 
 import argparse
+import warnings
+
 from tqdm import tqdm
 
 from pebblo.app.config.config import load_config
-import warnings
 
 warnings.filterwarnings("ignore", category=UserWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -34,6 +34,7 @@ def classifier_init(p_bar):
     p_bar.write("Downloading topic, entity classifier models ...")
     from pebblo.entity_classifier.entity_classifier import EntityClassifier
     from pebblo.topic_classifier.topic_classifier import TopicClassifier
+
     p_bar.update(3)
     p_bar.write("Initializing topic classifier ...")
     p_bar.update(1)
@@ -42,10 +43,10 @@ def classifier_init(p_bar):
     _ = TopicClassifier()
     p_bar.write("Initializing topic classifier ... done")
     p_bar.update(1)
-    
+
     p_bar.write("Initializing entity classifier ...")
     p_bar.update(1)
-    
+
     # Init EntityClassifier(This step downloads all necessary training models)
     _ = EntityClassifier()
     p_bar.write("Initializing entity classifier ... done")
@@ -57,6 +58,7 @@ def server_start(config: dict, p_bar: tqdm):
     p_bar.write("Pebblo server starting ...")
     # Starting Uvicorn Service Using config details
     from pebblo.app.config.service import Service
+
     p_bar.update(1)
     svc = Service(config_details=config)
     p_bar.update(2)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -4,8 +4,6 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 
 import argparse
 import warnings
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 
 from tqdm import tqdm
 
@@ -35,8 +33,7 @@ def start():
 def classifier_init(p_bar):
     """Initialize topic and entity classifier."""
     p_bar.write("Downloading topic, entity classifier models ...")
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        from pebblo.entity_classifier.entity_classifier import EntityClassifier
+    from pebblo.entity_classifier.entity_classifier import EntityClassifier
     from pebblo.topic_classifier.topic_classifier import TopicClassifier
 
     p_bar.update(3)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -43,14 +43,12 @@ def classifier_init(p_bar):
     p_bar.write("Initializing topic classifier ... done")
     p_bar.update(1)
     
-
     p_bar.write("Initializing entity classifier ...")
     p_bar.update(1)
     
     # Init EntityClassifier(This step downloads all necessary training models)
     _ = EntityClassifier()
     p_bar.write("Initializing entity classifier ... done")
-
     p_bar.update(1)
 
 

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -3,7 +3,6 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 """
 
 import argparse
-import sys
 from tqdm import tqdm
 
 from pebblo.app.config.config import load_config

--- a/pebblo/topic_classifier/libs/logger.py
+++ b/pebblo/topic_classifier/libs/logger.py
@@ -18,6 +18,8 @@ def get_logger():
     logger_obj.propagate = False
     if not logger_obj.handlers:
         logger_obj.addHandler(console_handle)
+    package_logger = logging.getLogger("transformers")
+    package_logger.setLevel(logging.ERROR)
     return logger_obj
 
 

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -4,9 +4,6 @@ Defines the TopicClassifier class with methods for predicting topics and extract
 """
 
 import os
-import warnings
-warnings.filterwarnings("ignore", category=UserWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning)
 from huggingface_hub import login
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 
@@ -33,7 +30,7 @@ class TopicClassifier:
         # Check if the environment variable exists
         if huggingface_token is not None:
             login(token=huggingface_token)
-            
+
         # Load the model and tokenizer from the specified paths and revision
         _tokenizer = AutoTokenizer.from_pretrained(
             TOKENIZER_PATH, revision=MODEL_REVISION

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -4,7 +4,9 @@ Defines the TopicClassifier class with methods for predicting topics and extract
 """
 
 import os
-
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 from huggingface_hub import login
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 
@@ -19,6 +21,7 @@ from pebblo.topic_classifier.enums.constants import topic_display_names
 from pebblo.topic_classifier.libs.logger import logger
 
 
+
 class TopicClassifier:
     """
     Class for topic classification
@@ -27,7 +30,6 @@ class TopicClassifier:
     def __init__(self):
         # Use os.environ.get() to retrieve the value of the environment variable
         huggingface_token = os.environ.get("HF_TOKEN")
-
         # Check if the environment variable exists
         if huggingface_token is not None:
             login(token=huggingface_token)

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -18,7 +18,6 @@ from pebblo.topic_classifier.enums.constants import topic_display_names
 from pebblo.topic_classifier.libs.logger import logger
 
 
-
 class TopicClassifier:
     """
     Class for topic classification
@@ -26,7 +25,9 @@ class TopicClassifier:
 
     def __init__(self):
         # Use os.environ.get() to retrieve the value of the environment variable
+
         huggingface_token = os.environ.get("HF_TOKEN")
+
         # Check if the environment variable exists
         if huggingface_token is not None:
             login(token=huggingface_token)

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -33,7 +33,7 @@ class TopicClassifier:
         # Check if the environment variable exists
         if huggingface_token is not None:
             login(token=huggingface_token)
-
+            
         # Load the model and tokenizer from the specified paths and revision
         _tokenizer = AutoTokenizer.from_pretrained(
             TOKENIZER_PATH, revision=MODEL_REVISION

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -4,6 +4,7 @@ Defines the TopicClassifier class with methods for predicting topics and extract
 """
 
 import os
+
 from huggingface_hub import login
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 


### PR DESCRIPTION
Because of this line in daemon.py

with redirect_stdout(StringIO()), redirect_stderr(StringIO()

logs and print statements were not working in the topic classifier because of which it was difficult to debug the classifier
On removing this line there were getting logs from "transformers" library. 
To suppress them code has been added in logger.py and warnings have been suppressed in topic_classifier.py

You can check the below image to see the difference

**Before** 

<img width="747" alt="before_change" src="https://github.com/daxa-ai/pebblo/assets/37294591/66099d2c-d358-4ea7-b693-1a835cf42c67">

**After**

<img width="741" alt="after_change" src="https://github.com/daxa-ai/pebblo/assets/37294591/fe584f67-5b29-4fe0-b1f9-47cb9f86bf45">
