### PR TITLE
Identity UI added for local ui and reports

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/Dialog.js
+++ b/pebblo/app/pebblo-ui/src/components/Dialog.js
@@ -22,16 +22,21 @@ const Dialog = (props) => {
     dialogId,
   } = props;
 
-  waitForElement(`#${dialogId}`, 100).then(function () {
+  waitForElement(`#${dialogId}`, 500).then(function () {
     const DIALOG__BTN = document.getElementById(btnId);
     const DIALOG = document.getElementById(dialogId);
+    DIALOG.style.display = "none";
     const CLOSE__DIALOG__BUTTON = document.getElementById(
       `${dialogId}_close_modal`
     );
     DIALOG__BTN.addEventListener(CLICK, () => {
+      DIALOG.style.display = "block";
       DIALOG.showModal();
     });
-    CLOSE__DIALOG__BUTTON.addEventListener(CLICK, () => DIALOG.close());
+    CLOSE__DIALOG__BUTTON.addEventListener(CLICK, () => {
+      DIALOG.style.display = "none";
+      DIALOG.close();
+    });
   });
 
   return /*html*/ `

--- a/pebblo/app/pebblo-ui/src/components/Dialog.js
+++ b/pebblo/app/pebblo-ui/src/components/Dialog.js
@@ -1,8 +1,9 @@
 import { CLICK, LOAD } from "../constants/enums.js";
 import CloseIcon from "../icons/closeIcon.js";
+import { waitForElement } from "../util.js";
 import { IconButton } from "./IconButton.js";
 
-// PROPS { 
+// PROPS {
 //   dialogBody: HTMLElement,
 //   fullWidth?:boolean,
 //   maxWidth?: string,
@@ -21,27 +22,28 @@ const Dialog = (props) => {
     dialogId,
   } = props;
 
-  window.addEventListener(LOAD, function () {
+  waitForElement(`#${dialogId}`, 100).then(function () {
     const DIALOG__BTN = document.getElementById(btnId);
     const DIALOG = document.getElementById(dialogId);
     const CLOSE__DIALOG__BUTTON = document.getElementById(
       `${dialogId}_close_modal`
     );
-    DIALOG__BTN.addEventListener(CLICK, () => DIALOG.showModal());
+    DIALOG__BTN.addEventListener(CLICK, () => {
+      DIALOG.showModal();
+    });
     CLOSE__DIALOG__BUTTON.addEventListener(CLICK, () => DIALOG.close());
   });
 
   return /*html*/ `
-    <dialog id="${dialogId}" class="flex flex-col gap-3 pt-4 pb-4 pr-4 pl-4 ${fullWidth ? "dialog-full" : ""
-    } ${maxWidth ? `dialog-${maxWidth}` : ""}">
+    <dialog id="${dialogId}" class="flex flex-col gap-3 pt-4 pb-4 pr-4 pl-4 ${
+    fullWidth ? "dialog-full" : ""
+  } ${maxWidth ? `dialog-${maxWidth}` : ""}">
         <div class="flex justify-between items-center">
           <div class="font-16 inter medium surface-10">${title}</div>
           ${IconButton({
-      id: `${dialogId}_close_modal`,
-      children:
-        CloseIcon({ class: "cursor-pointer" })
-      ,
-    })}
+            id: `${dialogId}_close_modal`,
+            children: CloseIcon({ class: "cursor-pointer" }),
+          })}
         </div>
         <div class="dialog-body">${dialogBody}</div>
     </dialog>`;

--- a/pebblo/app/pebblo-ui/src/components/bubbleChart.js
+++ b/pebblo/app/pebblo-ui/src/components/bubbleChart.js
@@ -2,7 +2,6 @@ import { waitForElement } from "../util.js";
 
 export const BubbleChart = (props) => {
   //const { types, data: chartData } = props;
-  console.log({ props });
   waitForElement("#bubbleChart", 5000).then(function () {
     const data = props.chartData;
     // Set the dimensions and margins of the graph
@@ -60,7 +59,6 @@ export const BubbleChart = (props) => {
       .style("position", "absolute");
 
     var showTooltip = function (event, d) {
-      console.log({ event, d });
       const xPos = event.clientX;
       const yPos = event.clientY;
       tooltip.transition().duration(200);

--- a/pebblo/app/pebblo-ui/src/components/chips.js
+++ b/pebblo/app/pebblo-ui/src/components/chips.js
@@ -2,9 +2,7 @@ import { Button, Dialog, Table } from "./index.js";
 import { IDENTITY_TABLE_COL } from "../constants/constant.js";
 
 export const Chips = (props) => {
-  const { list, showCount, fileName, dialogTitle } = props;
-  const btnId = fileName ? fileName.split("/").at(-1).split(".").at(0) : "1";
-
+  const { list, showCount, fileName, dialogTitle, id } = props;
   const DialogBody = () => {
     const TABLE_DATA = list.map((identityName) => ({ identity: identityName }));
     return /*html*/ `
@@ -16,18 +14,18 @@ export const Chips = (props) => {
 
   return list && list.length > 0
     ? /*html*/ `
-  <div class="flex items-center w-fit">
-    <div>${list[0]}</div>
+  <div class="flex items-center">
+    <div class="text-none">${list[0]}</div>
     ${Button({
       btnText: `+${list.length - 1}`,
-      id: `identity-dialog-${btnId}-btn`,
+      id: `identity-dialog-${id}-btn`,
     })}
     ${Dialog({
       title: dialogTitle,
       maxWidth: "md",
       dialogBody: DialogBody(),
-      dialogId: `identity-dialog-${btnId}`,
-      btnId: `identity-dialog-${btnId}-btn`,
+      dialogId: `identity-dialog-${id}`,
+      btnId: `identity-dialog-${id}-btn`,
     })}
   </div>
 `

--- a/pebblo/app/pebblo-ui/src/components/chips.js
+++ b/pebblo/app/pebblo-ui/src/components/chips.js
@@ -1,0 +1,35 @@
+import { Button, Dialog, Table } from "./index.js";
+import { IDENTITY_TABLE_COL } from "../constants/constant.js";
+
+export const Chips = (props) => {
+  const { list, showCount, fileName, dialogTitle } = props;
+  const btnId = fileName ? fileName.split("/").at(-1).split(".").at(0) : "1";
+
+  const DialogBody = () => {
+    const TABLE_DATA = list.map((identityName) => ({ identity: identityName }));
+    return /*html*/ `
+  <div class="load-history-table pt-6 pb-6 pr-6 pl-6 rounded-md">
+   ${Table({ tableCol: IDENTITY_TABLE_COL, tableData: TABLE_DATA })}
+  </div>
+  `;
+  };
+
+  return list && list.length > 0
+    ? /*html*/ `
+  <div class="flex items-center w-fit">
+    <div>${list[0]}</div>
+    ${Button({
+      btnText: `+${list.length - 1}`,
+      id: `identity-dialog-${btnId}-btn`,
+    })}
+    ${Dialog({
+      title: dialogTitle,
+      maxWidth: "md",
+      dialogBody: DialogBody(),
+      dialogId: `identity-dialog-${btnId}`,
+      btnId: `identity-dialog-${btnId}-btn`,
+    })}
+  </div>
+`
+    : "-";
+};

--- a/pebblo/app/pebblo-ui/src/components/index.js
+++ b/pebblo/app/pebblo-ui/src/components/index.js
@@ -12,16 +12,22 @@ import Dialog from "./Dialog.js";
 import { ChartCard } from "./chartCard.js";
 import { BubbleChart } from "./bubbleChart.js";
 import { LegendBadge } from "./legendBadge.js";
+import { Chips } from "./chips.js";
 
 export {
   AccordionDetails,
   AccordionSummary,
   ApplicationsList,
+  BubbleChart,
   Button,
   Card,
+  ChartCard,
+  Chips,
+  Dialog,
   Header,
   IconButton,
   KeyValue,
+  LegendBadge,
   SnippetDetails,
   Tabs,
   Tab,
@@ -29,8 +35,4 @@ export {
   Tbody,
   Thead,
   Td,
-  Dialog,
-  ChartCard,
-  LegendBadge,
-  BubbleChart,
 };

--- a/pebblo/app/pebblo-ui/src/components/snippetDetails.js
+++ b/pebblo/app/pebblo-ui/src/components/snippetDetails.js
@@ -57,6 +57,10 @@ export function SnippetDetails(props) {
                  key: "Retrieved From",
                  value: snipp?.sourcePath,
                })}
+               ${KeyValue({
+                 key: "Identity",
+                 value: snipp?.authorizedIdentities.join(", "),
+               })}
               <div class="divider-horizontal"></div>
              </div>
            `
@@ -107,6 +111,10 @@ export function SnippetDetails(props) {
                    key: "Retrieved From",
                    value: snipp?.sourcePath,
                  })}
+                ${KeyValue({
+                  key: "Identity",
+                  value: snipp?.authorizedIdentities.join(", "),
+                })}
                 <div class="divider-horizontal"></div>
                </div>
              `

--- a/pebblo/app/pebblo-ui/src/components/snippetDetails.js
+++ b/pebblo/app/pebblo-ui/src/components/snippetDetails.js
@@ -59,7 +59,10 @@ export function SnippetDetails(props) {
                })}
                ${KeyValue({
                  key: "Identity",
-                 value: snipp?.authorizedIdentities.join(", "),
+                 value:
+                   snipp?.authorizedIdentities?.length > 0
+                     ? snipp?.authorizedIdentities.join(", ")
+                     : "-",
                })}
               <div class="divider-horizontal"></div>
              </div>
@@ -113,7 +116,10 @@ export function SnippetDetails(props) {
                  })}
                 ${KeyValue({
                   key: "Identity",
-                  value: snipp?.authorizedIdentities.join(", "),
+                  value:
+                    snipp?.authorizedIdentities?.length > 0
+                      ? snipp?.authorizedIdentities.join(", ")
+                      : "-",
                 })}
                 <div class="divider-horizontal"></div>
                </div>

--- a/pebblo/app/pebblo-ui/src/components/table.js
+++ b/pebblo/app/pebblo-ui/src/components/table.js
@@ -93,7 +93,14 @@ function Tbody(props) {
 // }
 
 function Td(props) {
-  const { children, align = "start", link, isTooltip, tooltipTitle } = props;
+  const {
+    children,
+    align = "start",
+    link,
+    isTooltip,
+    tooltipTitle,
+    tooltipWidth,
+  } = props;
   const TEXT__ALIGN = getTextOrientation(align);
   let td;
   if (link) {
@@ -112,7 +119,9 @@ function Td(props) {
   }
   if (isTooltip) {
     return /*html*/ `
-    <td class="${TEXT__ALIGN} capitalize pt-3 pb-3 pl-3 pr-3 text-ellipsis">
+    <td class="${TEXT__ALIGN} capitalize pt-3 pb-3 pl-3 pr-3 ${
+      tooltipWidth ? tooltipWidth : "text-ellipsis"
+    }">
        ${Tooltip({
          children: children || "-",
          title: tooltipTitle,
@@ -142,6 +151,7 @@ const TABLE_BODY = (props) => {
          col?.field !== ACTIONS && link ? `${link}?app_name=${item?.name}` : "",
        isTooltip: col?.isTooltip,
        tooltipTitle: col?.tooltipTitle ? col?.tooltipTitle(item) : "",
+       tooltipWidth: col?.tooltipWidth,
      })
    )}
      </tr>`

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -1,5 +1,9 @@
 import { FindingsPanel } from "../components/findingsPanel.js";
-import { ApplicationsList, SnippetDetails } from "../components/index.js";
+import {
+  ApplicationsList,
+  Chips,
+  SnippetDetails,
+} from "../components/index.js";
 import { Tooltip } from "../components/tooltip.js";
 import { CopyIcon } from "../icons/index.js";
 import { DownloadIcon } from "../icons/index.js";
@@ -123,14 +127,43 @@ export const FILES_WITH_FINDINGS_TABLE = [
     align: "start",
   },
   {
-    label: "Findings-Topics",
-    field: "findingsTopics",
+    label: "Size",
+    field: "sourceSize",
     align: "end",
   },
   {
-    label: "Findings-Entities",
-    field: "findingsEntities",
+    label: "Findings",
+    field: "findingsTopics",
+    render: (item) => item.findingsEntities + item.findingsTopics,
+    isTooltip: true,
+    tooltipTitle: (item) => `
+      <div class="surface-main flex flex-col gap-1 inter font-12 font-300 w-10">
+        <div class="flex justify-between">
+        <div>Topics</div>
+        <div>${item.findingsTopics}</div>
+        </div>
+        <div class="flex justify-between">
+        <div>Entities</div>
+        <div>${item.findingsEntities}</div>
+        </div>
+      </div>`,
+    tooltipWidth: "fit",
     align: "end",
+  },
+  {
+    label: "Identities",
+    field: "authorizedIdentities",
+    render: (item) =>
+      Chips({
+        list: item?.authorizedIdentities,
+        showCount: 1,
+        fileName: item?.fileName,
+        dialogTitle: `<div class="flex gap-4 items-center">
+        <div>Identities (${item?.authorizedIdentities?.length})</div>
+        <div class="font-12 surface-10-opacity-50">Document: ${item?.fileName}</div>
+      </div>`,
+      }),
+    align: "start",
   },
   {
     label: "Data Source",
@@ -168,12 +201,20 @@ export const TABLE_DATA_FOR_APPLICATIONS = [
     align: "start",
   },
   {
-    label: "Findings - Topics",
+    label: "Findings - Total",
+    field: "total",
+    render: (item) => {
+      return item.topics + item.entities;
+    },
+    align: "end",
+  },
+  {
+    label: "Topics",
     field: "topics",
     align: "end",
   },
   {
-    label: "Findings - Entities",
+    label: "Entities",
     field: "entities",
     align: "end",
   },
@@ -249,23 +290,52 @@ export const TABLE_DATA_FOR_FILES_WITH_FINDINGS = [
     tooltipTitle: (item) => item.sourceFilePath,
   },
   {
-    label: "Findings-Topics",
+    label: "Size",
+    field: "sourceSize",
+    align: "end",
+  },
+  {
+    label: "Findings",
     field: "findingsTopics",
+    render: (item) => item.findingsEntities + item.findingsTopics,
+    isTooltip: true,
+    tooltipTitle: (item) => `
+      <div class="surface-main flex flex-col gap-1 inter font-12 font-300 w-10">
+        <div class="flex justify-between">
+        <div>Topics</div>
+        <div>${item.findingsTopics}</div>
+        </div>
+        <div class="flex justify-between">
+        <div>Entities</div>
+        <div>${item.findingsEntities}</div>
+        </div>
+      </div>`,
+    tooltipWidth: "fit",
     align: "end",
   },
   {
-    label: "Findings-Entities",
-    field: "findingsEntities",
-    align: "end",
-  },
-  {
-    label: "Data Source",
-    field: "sourceName",
+    label: "Identities",
+    field: "authorizedIdentities ",
+    render: (item) =>
+      Chips({
+        list: item?.authorizedIdentities,
+        showCount: 1,
+        fileName: item?.sourceFilePath,
+        dialogTitle: `<div class="flex gap-4 items-center">
+        <div>Identities (${item?.authorizedIdentities?.length})</div>
+        <div class="font-12 surface-10-opacity-50">Document: ${item?.sourceFilePath}</div>
+      </div>`,
+      }),
     align: "start",
   },
   {
     label: "Application",
     field: "appName",
+    align: "start",
+  },
+  {
+    label: "Data Source",
+    field: "sourceName",
     align: "start",
   },
 ];
@@ -661,3 +731,11 @@ export const LOAD_HISTORY_TABLE_DATA = APP_DATA?.loadHistory?.history?.map(
     generatedOn: getFormattedDate(loadHistoryItem?.generatedOn, true, false),
   })
 );
+
+export const IDENTITY_TABLE_COL = [
+  {
+    label: "Identity",
+    field: "identity",
+    align: "start",
+  },
+];

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -747,5 +747,6 @@ export const IDENTITY_TABLE_COL = [
     label: "Identity",
     field: "identity",
     align: "start",
+    render: (item) => `<div class="text-none">${item?.identity || "-"}</div>`,
   },
 ];

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -7,7 +7,7 @@ import {
 import { Tooltip } from "../components/tooltip.js";
 import { CopyIcon } from "../icons/index.js";
 import { DownloadIcon } from "../icons/index.js";
-import { extractTimezone, getFormattedDate } from "../util.js";
+import { extractTimezone, getFileSize, getFormattedDate } from "../util.js";
 import { APP_DETAILS_ROUTE } from "./routesConstant.js";
 
 const SCRIPT_ELEMENT = document.getElementById("main_script");
@@ -120,7 +120,7 @@ export const FILES_WITH_FINDINGS_TABLE = [
     <div class="flex flex-col inter">
        <div class="surface-10 font-13">${item.fileName || "-"}</div>
        <div class="surface-10-opacity-50 font-12 flex">
-         <div>${item?.sourceSize || "-"} | ${item?.fileOwner || "-"}</div>
+         <div>${item?.fileOwner || "-"}</div>
        </div>
     </div>
  `,
@@ -130,6 +130,7 @@ export const FILES_WITH_FINDINGS_TABLE = [
     label: "Size",
     field: "sourceSize",
     align: "end",
+    render: (item) => getFileSize(item?.sourceSize),
   },
   {
     label: "Findings",
@@ -293,6 +294,7 @@ export const TABLE_DATA_FOR_FILES_WITH_FINDINGS = [
     label: "Size",
     field: "sourceSize",
     align: "end",
+    render: (item) => getFileSize(item?.sourceSize),
   },
   {
     label: "Findings",
@@ -347,9 +349,9 @@ export const TABLE_DATA_FOR_DATA_SOURCE = [
     render: (item) => /*html*/ `
       <div class="flex flex-col inter">
          <div class="surface-10 font-13">${item.name || "-"}</div>
-         <div class="surface-10-opacity-50 font-12">${item.sourceSize} | ${
-      item.sourcePath
-    }</div>
+         <div class="surface-10-opacity-50 font-12">${
+           item?.sourceSize ? getFileSize(item.sourceSize) : "-"
+         } | ${item.sourcePath}</div>
       </div>
    `,
     align: "start",

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -159,6 +159,7 @@ export const FILES_WITH_FINDINGS_TABLE = [
         list: item?.authorizedIdentities,
         showCount: 1,
         fileName: item?.fileName,
+        id: item.id,
         dialogTitle: `<div class="flex gap-4 items-center">
         <div>Identities (${item?.authorizedIdentities?.length})</div>
         <div class="font-12 surface-10-opacity-50">Document: ${item?.fileName}</div>
@@ -323,10 +324,11 @@ export const TABLE_DATA_FOR_FILES_WITH_FINDINGS = [
         list: item?.authorizedIdentities,
         showCount: 1,
         fileName: item?.sourceFilePath,
+        id: item.id,
         dialogTitle: `<div class="flex gap-4 items-center">
-        <div>Identities (${item?.authorizedIdentities?.length})</div>
-        <div class="font-12 surface-10-opacity-50">Document: ${item?.sourceFilePath}</div>
-      </div>`,
+      <div>Identities (${item?.authorizedIdentities?.length})</div>
+      <div class="font-12 surface-10-opacity-50">Document: ${item?.sourceFilePath}</div>
+    </div>`,
       }),
     align: "start",
   },
@@ -380,9 +382,9 @@ export const TABLE_DATA_FOR_DATA_SOURCE_APP_DETAILS = [
     render: (item) => /*html*/ `
       <div class="flex flex-col inter">
          <div class="surface-10 font-13">${item.name || "-"}</div>
-         <div class="surface-10-opacity-50 font-12">${item.sourceSize} | ${
-      item.sourcePath
-    }</div>
+         <div class="surface-10-opacity-50 font-12">${
+           item.sourceSize ? getFileSize(item.sourceSize) : ""
+         } | ${item.sourcePath}</div>
       </div>
    `,
     align: "start",
@@ -519,7 +521,10 @@ export const TAB_PANEL_ARR_FOR_APPLICATIONS = [
     value: {
       title: "Documents With Findings",
       tableCol: TABLE_DATA_FOR_FILES_WITH_FINDINGS,
-      tableData: APP_DATA?.documentsWithFindings,
+      tableData: APP_DATA?.documentsWithFindings?.map((finding, index) => ({
+        ...finding,
+        id: index,
+      })),
       isDownloadReport: false,
       error: NO_APPLICATIONS_FOUND ? "ENABLE_PEBBLO_EMPTY_STATE" : null,
       searchField: ["sourceFilePath", "appName"],
@@ -651,7 +656,10 @@ export const TAB_PANEL_ARR_FOR_APPLICATION_DETAILS = [
     value: {
       title: "Documents With Findings",
       tableCol: FILES_WITH_FINDINGS_TABLE,
-      tableData: APP_DATA?.topFindings,
+      tableData: APP_DATA?.topFindings?.map((finding, index) => ({
+        ...finding,
+        id: index,
+      })),
       searchField: ["fileName"],
       isSorting: true,
       inputPlaceholder: "Search by File",

--- a/pebblo/app/pebblo-ui/src/util.js
+++ b/pebblo/app/pebblo-ui/src/util.js
@@ -98,3 +98,20 @@ export const SORT_DATA = (array, order, key) => {
   }
   return array.sort((a, b) => b[key] - a[key]);
 };
+
+export const getFileSize = (size) => {
+  // Returns file size in KB, MB, GB as applicable
+  if (size && size !== "-") {
+    const power = 2 ** 10;
+    let n = 0;
+    const powerLabels = { 0: "Bytes", 1: "KB", 2: "MB", 3: "GB", 4: "TB" };
+    while (size > power) {
+      size /= power;
+      n++;
+    }
+    const sizeNum = parseFloat(size.toFixed(2));
+    const sizeStr = sizeNum.toString() + " " + (powerLabels[n] || "");
+    return sizeStr;
+  }
+  return "-";
+};

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -254,7 +254,9 @@ svg.icon-success {
 .capitalize {
   text-transform: capitalize;
 }
-
+.text-none {
+  text-transform: none;
+}
 /* ELLIPSE TEXT  */
 .text-ellipsis {
   max-width: 0;

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -113,6 +113,15 @@ svg.icon-success {
 .w-70 {
   width: 70%;
 }
+.w-10 {
+  width: 100px;
+}
+.w-auto {
+  width: auto;
+}
+.w-fit {
+  width: fit-content;
+}
 
 /* <----------- FONT FAMILY -----------> */
 .inter {
@@ -326,6 +335,9 @@ svg.icon-success {
 /* <----------- COLOR -----------> */
 .surface-white {
   color: var(--white);
+}
+.surface-main {
+  color: var(--main);
 }
 .surface-10 {
   color: var(--surface-10);
@@ -1100,7 +1112,7 @@ dialog::backdrop {
 }
 .tooltip:hover .tooltip-wrapper-top {
   visibility: visible;
-  top: -24px;
+  top: -30px;
   left: 0;
 }
 

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -30,6 +30,13 @@ def get_file_size(size):
     return size_str
 
 
+def identity_comma_separated(identity_list):
+    """Returns comma separated list of identities"""
+    if identity_list:
+        return ", ".join(identity_list)
+    return "-"
+
+
 def convert_html_to_pdf(data, output_path, template_name, search_path, renderer):
     """Convert HTML Template to PDF by embedding JSON data"""
     try:
@@ -60,6 +67,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
             dateFormatter=date_formatter,
             getFileSize=get_file_size,
             findings_count=findings_count,
+            identity_comma_separated=identity_comma_separated,
         )
         pdf_converter = library_function_mapping[renderer]
         status, result = pdf_converter(source_html, output_path, search_path)

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -111,6 +111,7 @@
                   <th class="medium text-end">Findings - Topics</th>
                   <th class="medium text-end">Findings - Entities</th>
                   <th class="medium">Owner</th>
+                  <th class="medium">Identity</th>
                 </tr>
               </thead>
               <tbody class="surface-10 font-13">
@@ -126,6 +127,9 @@
                     {{ item.findingsEntities|default('-') }}
                   </td>
                   <td>{{ item.fileOwner|default('-') }}</td>
+                  <td>
+                    {{ identity_comma_separated(item.authorizedIdentities) }}
+                  </td>
                 </tr>
                 {% endfor %}
               </tbody>
@@ -355,6 +359,12 @@
               <div class="surface-50 font-12">Retrieved From</div>
               <div class="surface-10 font-13 mt-2">
                 {{ snippet.sourcePath }}
+              </div>
+            </div>
+            <div class="key-value">
+              <div class="surface-50 font-12">Identity</div>
+              <div class="surface-10 font-13 mt-2">
+                {{ identity_comma_separated(snippet.authorizedIdentities) }}
               </div>
             </div>
             <!-- <div class="key-value">

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -987,9 +987,7 @@
             </div>
             <div class="key-value">
               <div class="surface-50 font-12 medium">Retrieved From</div>
-              <div
-                class="surface-10 font-13 mt-2 break-all normal td-border pb-2"
-              >
+              <div class="surface-10 font-13 mt-2 break-all normal pb-2">
                 {{ snippet.sourcePath }}
               </div>
             </div>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -729,13 +729,14 @@
                   <th class="th-colored normal align-cell-left">
                     Document Name
                   </th>
-                  <th class="th-colored normal text-end w-120 align-cell-right">
+                  <th class="th-colored normal text-end align-cell-right">
                     Findings - Topics
                   </th>
-                  <th class="th-colored normal text-end w-120 align-cell-right">
+                  <th class="th-colored normal text-end align-cell-right">
                     Findings - Entities
                   </th>
-                  <th class="th-colored normal w-120 align-cell-left">Owner</th>
+                  <th class="th-colored normal align-cell-left">Owner</th>
+                  <th class="th-colored normal align-cell-left">Identity</th>
                 </tr>
               </thead>
               <tbody class="surface-10 normal font-13">
@@ -750,6 +751,9 @@
                   </td>
                   <td class="text-end w-120 align-cell-center">
                     {{ item.fileOwner|default('-') }}
+                  </td>
+                  <td>
+                    {{ identity_comma_separated(item.authorizedIdentities) }}
                   </td>
                 </tr>
                 {% endfor %}
@@ -987,6 +991,14 @@
                 class="surface-10 font-13 mt-2 break-all normal td-border pb-2"
               >
                 {{ snippet.sourcePath }}
+              </div>
+            </div>
+            <div class="key-value">
+              <div class="surface-50 font-12 medium">Identity</div>
+              <div
+                class="surface-10 font-13 mt-2 break-all normal td-border pb-2"
+              >
+                {{ identity_comma_separated(snippet.authorizedIdentities) }}
               </div>
             </div>
             <!-- <div class="key-value">

--- a/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
+++ b/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
@@ -11,7 +11,6 @@ from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
-
 from utils import format_text, get_input_as_list
 
 load_dotenv()

--- a/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
+++ b/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 from dotenv import load_dotenv
 from langchain.chains import PebbloRetrievalQA

--- a/pebblo_saferetriever/langchain/semantic-rag/utils.py
+++ b/pebblo_saferetriever/langchain/semantic-rag/utils.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Optional, List
+from typing import List, Optional
 
 
 def format_text(text: str, width: int = 120):

--- a/tests/reports/test_report_generator.py
+++ b/tests/reports/test_report_generator.py
@@ -11,6 +11,7 @@ from pebblo.reports.html_to_pdf_generator.report_generator import (
     convert_html_to_pdf,
     date_formatter,
     get_file_size,
+    identity_comma_separated,
 )
 
 
@@ -23,6 +24,7 @@ class TestReportGenerator(unittest.TestCase):
             "2024-02-02 16:25:07.531509", "%Y-%m-%d %H:%M:%S.%f"
         )
         self.file_size = 2092
+        self.authorizedIdentities = ["demo-user-hr", "demo-user-engg"]
 
     def test_date_formatter(self):
         """Test if date formatter returns correct string"""
@@ -33,6 +35,11 @@ class TestReportGenerator(unittest.TestCase):
         """Test file size conversion"""
         output_size = get_file_size(self.file_size)
         assert output_size == "2.04 KB"
+
+    def test_identity_comma_separated(self):
+        """Test comma separated identities"""
+        output_str = identity_comma_separated(self.authorizedIdentities)
+        assert output_str == "demo-user-hr, demo-user-engg"
 
     @patch("jinja2.Environment", return_value=Mock(get_template=Mock()))
     @patch("jinja2.FileSystemLoader")


### PR DESCRIPTION
**Added Identity details for Pebblo UI:**

1. Added identity list for findings:
<img width="1264" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/a6d79c60-a26e-48ca-b838-c1e03484386b">

Dialog shows all identities: 
<img width="1245" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/c2f4f024-43a2-4ece-8d4c-f695bf9f27b3">


2. Added identity details in snippets:
<img width="1244" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/471798bf-2e65-4365-bca9-1e03494516f4">



**Report PDFs:**

- xhtml2pdf Report PDF:
1. Added identity details in Top Findings table:
<img width="754" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/961276c2-b2a9-4889-b690-e0c22d5dc9ff">

2. Updated snippets:
<img width="756" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/bb88d5c0-260e-422b-a35b-333f055289db">


- weasyprint Report PDF:
1. Added identity details in Top Findings table:
<img width="615" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/b060bd26-e481-4984-ae4c-cb3241b3ab71">



2. Updated snippets:
<img width="615" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/8c9d5c7b-eac7-4572-81fe-14a2fd6d950d">


