### PR TITLE
Update Tooltip UI and truncate long file names in table in Local UI

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/tooltip.js
+++ b/pebblo/app/pebblo-ui/src/components/tooltip.js
@@ -9,6 +9,6 @@ export function Tooltip(props) {
   return /*html*/ `
   <div class="tooltip">
   <div class="tooltip-content">${children}</div>
-  <span class="tooltip-wrapper-${variant}"><span class="tooltip-title-${variant}">${title}</span></span></div>
+  <span class="tooltip-wrapper tooltip-wrapper-${variant}"><span class="tooltip-title-${variant}">${title}</span></span></div>
    `;
 }

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -129,6 +129,8 @@ export const FILES_WITH_FINDINGS_TABLE = [
     </div>
  `,
     align: "start",
+    isTooltip: true,
+    tooltipTitle: (item) => item.fileName,
   },
   {
     label: "Size",
@@ -165,9 +167,9 @@ export const FILES_WITH_FINDINGS_TABLE = [
         fileName: item?.fileName,
         id: item.id,
         dialogTitle: `<div class="flex gap-4 items-center">
-        <div>Identities (${item?.authorizedIdentities?.length})</div>
-        <div class="font-12 surface-10-opacity-50">Document: ${item?.fileName}</div>
-      </div>`,
+          <div>Identities (${item?.authorizedIdentities?.length})</div>
+          <div class="font-12 surface-10-opacity-50 overflow-ellipsis w-400px overflow-hidden" title="${item.fileName}">Document: ${item?.fileName}</div>     
+        </div>`,
       }),
     align: "start",
   },

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -1130,7 +1130,7 @@ dialog::backdrop {
 }
 .tooltip:hover .tooltip-wrapper-top {
   display: block;
-  bottom: -50%;
+  top: 20px;
   left: 0;
 }
 
@@ -1252,6 +1252,7 @@ dialog::backdrop {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  position: relative;
 }
 
 .tooltip-heading {

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -104,6 +104,9 @@ svg.icon-success {
 .w-full {
   width: 100%;
 }
+.w-half {
+  width: 50%;
+}
 .w-50 {
   width: 200px;
 }
@@ -115,6 +118,9 @@ svg.icon-success {
 }
 .w-10 {
   width: 100px;
+}
+.w-400px {
+  width: 400px;
 }
 .w-auto {
   width: auto;
@@ -260,6 +266,9 @@ svg.icon-success {
 /* ELLIPSE TEXT  */
 .text-ellipsis {
   max-width: 0;
+  text-overflow: ellipsis;
+}
+.overflow-ellipsis {
   text-overflow: ellipsis;
 }
 
@@ -916,7 +925,7 @@ tbody {
 td {
   border-bottom: 0.5px solid rgba(25, 28, 46, 0.2);
   position: relative;
-  z-index: 0;
+  /*z-index: 0;*/
 }
 td > #link {
   text-decoration: none;
@@ -1098,6 +1107,13 @@ dialog::backdrop {
 
 /* TOOLTIP */
 
+.tooltip-wrapper {
+  word-break: break-all;
+  white-space: normal;
+  width: 90%;
+  z-index: 1;
+}
+
 .tooltip-content {
   min-width: 100%;
   width: 100%;
@@ -1110,12 +1126,16 @@ dialog::backdrop {
 .tooltip-wrapper-bottom,
 .tooltip-wrapper-left {
   position: absolute;
-  visibility: hidden;
+  display: none;
 }
 .tooltip:hover .tooltip-wrapper-top {
-  visibility: visible;
-  top: -30px;
+  display: block;
+  bottom: -50%;
   left: 0;
+}
+
+.tooltip:hover .tooltip-wrapper-bottom {
+  display: block;
 }
 
 .tooltip-title-top {
@@ -1132,21 +1152,19 @@ dialog::backdrop {
 .tooltip-title-top:after {
   content: "";
   position: absolute;
-  top: 100%;
+  top: -10px;
   left: 50%;
   margin-left: -5px;
   border-width: 5px;
   border-style: solid;
   border-color: black transparent transparent transparent;
+  transform: rotate(180deg);
 }
 
 .tooltip:hover .tooltip-wrapper-bottom {
-  visibility: visible;
-  top: 0;
-  left: 0;
+  display: block;
   height: fit-content;
-  width: 100%;
-  margin: auto;
+  width: fit-content;
   bottom: 0;
 }
 
@@ -1189,7 +1207,7 @@ dialog::backdrop {
   z-index: 1;
   top: 150%;
   margin-left: -24px;
-  visibility: hidden;
+  display: none;
 }
 
 .copy-text-tooltip::after {


### PR DESCRIPTION

1. Truncate long file names and add tooltip:
<img width="1262" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/350552ad-bb92-4949-a9a8-48d44ddfc8d3">
2. In Identity Dialog, limit _**Document name**_ string width and add tooltip on hover:
<img width="968" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/a848f15e-b609-4f95-a6c2-8c1099b7c752">
