### PR TITLE
Entity Classifier Fix

### DIFF
--- a/pebblo/entity_classifier/entity_classifier.py
+++ b/pebblo/entity_classifier/entity_classifier.py
@@ -20,6 +20,7 @@ class EntityClassifier:
         self.anonymizer = AnonymizerEngine()
         self.entities = list(Entities.__members__.keys())
         self.entities.extend(list(SecretEntities.__members__.keys()))
+        self.custom_analyze()
 
     def custom_analyze(self):
         # Adding custom analyzer
@@ -91,7 +92,6 @@ class EntityClassifier:
             logger.debug("Presidio Entity Classifier and Anonymizer Started.")
             logger.debug(f"Data Input: {input_text}")
 
-            self.custom_analyze()
             analyzer_results = self.analyze_response(input_text)
             anonymized_response, anonymized_text = self.anonymize_response(
                 analyzer_results, input_text


### PR DESCRIPTION
After analysis it turned out that `custom_analyze()` is about initializing customer analyzer logic and was taking longer time. By moving this to init() made the difference.

Test data : csv with 3k lines.

| Test Data | Time Taken | with this fix |
| -- | -- | --  |
| csv with 3k records | ~40min | No |
| csv with 3k records | ~4min | Yes |