### PR TITLE
Changes in /prompt API

### DIFF
--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -223,13 +223,13 @@ class DiscoverAIAppsResponseModel(BaseModel):
 
 
 class RetrievalContext(BaseModel):
-    retrieved_from: list[str]
+    retrieved_from: str
     doc: str
     vector_db: str
 
 
 class RetrievalData(BaseModel):
-    context: RetrievalContext
+    context: list[RetrievalContext]
     prompt: AiDataModel
     response: AiDataModel
     prompt_time: str

--- a/pebblo/app/service/prompt_service.py
+++ b/pebblo/app/service/prompt_service.py
@@ -32,20 +32,22 @@ class Prompt:
         """
         logger.debug("Retrieving retrieval context details from input data")
         # Fetching retrieval context details
-        retrieval_context = {}
+        retrieval_context_output = []
         context_data = self.data.get("context")
-        fields_validator(context_data, ["retrieved_from", "doc", "vector_db"])
         if context_data:
-            retrieval_context = RetrievalContext(
-                retrieved_from=context_data.get("retrieved_from"),
-                doc=context_data.get("doc"),
-                vector_db=context_data.get("vector_db"),
-            )
+            for data in context_data:
+                fields_validator(data, ["retrieved_from", "doc", "vector_db"])
+                retrieval_context = RetrievalContext(
+                    retrieved_from=data.get("retrieved_from"),
+                    doc=data.get("doc"),
+                    vector_db=data.get("vector_db"),
+                )
+                retrieval_context_output.append(retrieval_context.dict())
 
         logger.debug(
-            f"AI_APPS [{self.application_name}]: Retrieval Context Details: {retrieval_context.dict()}"
+            f"AI_APPS [{self.application_name}]: Retrieval Context Details: {retrieval_context_output}"
         )
-        return retrieval_context
+        return retrieval_context_output
 
     def _fetch_context_data(self, param):
         """
@@ -56,6 +58,7 @@ class Prompt:
         data = {}
         context_data = self.data.get(param)
         if context_data:
+            fields_validator(context_data, ["data"])
             data = AiDataModel(
                 data=context_data.get("data"),
                 entityCount=context_data.get("entityCount")
@@ -82,7 +85,7 @@ class Prompt:
         Create an RetrievalData Model and return the corresponding model object
         """
         logger.debug("Creating RetrievalData model")
-
+        fields_validator(self.data, ["prompt_time", "user"])
         retrieval_data_model = RetrievalData(
             context=retrieval_context_data,
             prompt=prompt_data,

--- a/tests/app/test_prompt_api.py
+++ b/tests/app/test_prompt_api.py
@@ -27,11 +27,18 @@ def test_app_prompt_success(mock_write_json_to_file):
     mock_write_json_to_file.return_value = None
     test_payload = {
         "name": "Test App",
-        "context": {
-            "retrieved_from": ["test_data.pdf"],
-            "doc": "This is test doc.",
-            "vector_db": "ChromaDB",
-        },
+        "context": [
+            {
+                "retrieved_from": "test_data.pdf",
+                "doc": "This is test doc.",
+                "vector_db": "ChromaDB",
+            },
+            {
+                "retrieved_from": "test_data1.pdf",
+                "doc": "This is test1 doc.",
+                "vector_db": "ChromaDB",
+            },
+        ],
         "prompt": {"data": "What is Sachin's Passport ID?"},
         "response": {"data": "His passport ID is 5484880UA."},
         "prompt_time": "Wed 17 Apr, 2024, 15:03 PM",
@@ -51,7 +58,7 @@ def test_app_prompt_validation_errors(mock_write_json_to_file):
     mock_write_json_to_file.return_value = None
     test_payload = {
         "name": "Test App",
-        "context": {"retrieved_from": ["test_data.pdf"]},
+        "context": [{"retrieved_from": "test_data.pdf"}],
     }
     response = client.post("/v1/prompt", json=test_payload)
     assert response.status_code == 500
@@ -65,11 +72,18 @@ def test_app_prompt_server_error(mock_write_json_to_file):
     mock_write_json_to_file.side_effect = Exception("Mocked exception")
     test_payload = {
         "name": "Test App",
-        "context": {
-            "retrieved_from": ["test_data.pdf"],
-            "doc": "This is test doc.",
-            "vector_db": "ChromaDB",
-        },
+        "context": [
+            {
+                "retrieved_from": "test_data.pdf",
+                "doc": "This is test doc.",
+                "vector_db": "ChromaDB",
+            },
+            {
+                "retrieved_from": "test_data1.pdf",
+                "doc": "This is test1 doc.",
+                "vector_db": "ChromaDB",
+            },
+        ],
         "prompt": {"data": "What is Sachin's Passport ID?"},
         "response": {"data": "His passport ID is 5484880UA."},
         "prompt_time": "Wed 17 Apr, 2024, 15:03 PM",


### PR DESCRIPTION
**Description:** There is a slight change in request and response structure format of _/v1/prompt_ API

**Updated Payload**
```
{
  "name": "acme-corp-rag-123",
  "context": [
    {
      "retrieved_from": "data_topic.csv",
      "doc": "Sachin's SSN is 222-85. His AWS Access Key is: AKIPT4PDORIRTV6PH. His Passport ID is 5484880UA. And Github Token is: ghpu657yiujgwfrtigu3ver238765tyuhygvtrder6t7gyvhbuy5e676578976tyghy76578uygfyfgcyturtdf",
      "vector_db": "ChromaDB"
    },
    {
      "retrieved_from": "test_data.pdf",
      "doc": "Sachin's SSN is 222-85. His AWS Access Key is: AKIPT4PDORIRTV6PH. His Passport ID is 5484880UA. And Github Token is: ghpu657yiujgwfrtigu3ver238765tyuhygvtrder6t7gyvhbuy5e676578976tyghy76578uygfyfgcyturtdf",
      "vector_db": "ChromaDB234"
    }
  ],
  "prompt": {
    "data": "What is Sachin's Name?"
  },
  "response": {
    "data": "His name is Sachin"
  },
  "prompt_time": "Wed 19 Apr, 2024, 12:35 PM",
  "user": "dristy123"
}
```

Updated UTs accordingly
