### PR TITLE
Use GoogleDriveLoader from langchain_google_community

### DIFF
--- a/pebblo_cloud/langchain/rag-sample/rag_sample.py
+++ b/pebblo_cloud/langchain/rag-sample/rag_sample.py
@@ -3,10 +3,8 @@ from typing import List
 
 from dotenv import load_dotenv
 from langchain.schema import Document
-from langchain_community.document_loaders import (
-    GoogleDriveLoader,
-    UnstructuredFileIOLoader,
-)
+from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings

--- a/pebblo_cloud/langchain/rag-sample/rag_sample.py
+++ b/pebblo_cloud/langchain/rag-sample/rag_sample.py
@@ -4,9 +4,9 @@ from typing import List
 from dotenv import load_dotenv
 from langchain.schema import Document
 from langchain_community.document_loaders import UnstructuredFileIOLoader
-from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
+from langchain_google_community import GoogleDriveLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 
 load_dotenv()

--- a/pebblo_cloud/langchain/rag-sample/requirements.txt
+++ b/pebblo_cloud/langchain/rag-sample/requirements.txt
@@ -8,3 +8,4 @@ google-auth-httplib2
 google-auth-oauthlib
 unstructured[all-docs]
 qdrant-client
+langchain_google_community # For GoogleDriveLoader

--- a/pebblo_cloud/langchain/rag-sample/semantic_rag_sample.py
+++ b/pebblo_cloud/langchain/rag-sample/semantic_rag_sample.py
@@ -2,10 +2,8 @@ from typing import List
 
 from dotenv import load_dotenv
 from langchain.schema import Document
-from langchain_community.document_loaders import (
-    GoogleDriveLoader,
-    UnstructuredFileIOLoader,
-)
+from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings

--- a/pebblo_cloud/langchain/rag-sample/semantic_rag_sample.py
+++ b/pebblo_cloud/langchain/rag-sample/semantic_rag_sample.py
@@ -3,9 +3,9 @@ from typing import List
 from dotenv import load_dotenv
 from langchain.schema import Document
 from langchain_community.document_loaders import UnstructuredFileIOLoader
-from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
+from langchain_google_community import GoogleDriveLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 
 load_dotenv()

--- a/pebblo_safeloader/langchain/identity-rag/pebblo_identity_safeload.py
+++ b/pebblo_safeloader/langchain/identity-rag/pebblo_identity_safeload.py
@@ -2,10 +2,8 @@ from typing import List
 
 from dotenv import load_dotenv
 from langchain.schema import Document
-from langchain_community.document_loaders import (
-    GoogleDriveLoader,
-    UnstructuredFileIOLoader,
-)
+from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings

--- a/pebblo_safeloader/langchain/identity-rag/pebblo_identity_safeload.py
+++ b/pebblo_safeloader/langchain/identity-rag/pebblo_identity_safeload.py
@@ -3,9 +3,9 @@ from typing import List
 from dotenv import load_dotenv
 from langchain.schema import Document
 from langchain_community.document_loaders import UnstructuredFileIOLoader
-from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
+from langchain_google_community import GoogleDriveLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 
 load_dotenv()

--- a/pebblo_saferetriever/langchain/identity-rag/pebblo_identity_rag.py
+++ b/pebblo_saferetriever/langchain/identity-rag/pebblo_identity_rag.py
@@ -3,9 +3,9 @@ from dotenv import load_dotenv
 from google_auth import get_authorized_identities
 from langchain.chains import PebbloRetrievalQA
 from langchain_community.document_loaders import UnstructuredFileIOLoader
-from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
+from langchain_google_community import GoogleDriveLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
 

--- a/pebblo_saferetriever/langchain/identity-rag/pebblo_identity_rag.py
+++ b/pebblo_saferetriever/langchain/identity-rag/pebblo_identity_rag.py
@@ -2,10 +2,8 @@
 from dotenv import load_dotenv
 from google_auth import get_authorized_identities
 from langchain.chains import PebbloRetrievalQA
-from langchain_community.document_loaders import (
-    GoogleDriveLoader,
-    UnstructuredFileIOLoader,
-)
+from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings

--- a/pebblo_saferetriever/langchain/identity-rag/requirements.txt
+++ b/pebblo_saferetriever/langchain/identity-rag/requirements.txt
@@ -11,3 +11,4 @@ google-auth-httplib2
 google-auth-oauthlib
 qdrant-client==1.8.0 # for Qdrant VectorStore
 PyPDF2
+langchain_google_community # For GoogleDriveLoader

--- a/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
+++ b/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
@@ -4,9 +4,9 @@ from dotenv import load_dotenv
 from langchain.chains import PebbloRetrievalQA
 from langchain.chains.pebblo_retrieval.models import SemanticContext
 from langchain_community.document_loaders import UnstructuredFileIOLoader
-from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
+from langchain_google_community import GoogleDriveLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
 from utils import format_text, get_input_as_list

--- a/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
+++ b/pebblo_saferetriever/langchain/semantic-rag/pebblo_semantic_rag.py
@@ -3,10 +3,8 @@ from typing import List, Optional
 from dotenv import load_dotenv
 from langchain.chains import PebbloRetrievalQA
 from langchain.chains.pebblo_retrieval.models import SemanticContext
-from langchain_community.document_loaders import (
-    GoogleDriveLoader,
-    UnstructuredFileIOLoader,
-)
+from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_google_community import GoogleDriveLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
 from langchain_openai.embeddings import OpenAIEmbeddings

--- a/pebblo_saferetriever/langchain/semantic-rag/requirements.txt
+++ b/pebblo_saferetriever/langchain/semantic-rag/requirements.txt
@@ -10,3 +10,4 @@ google-auth-httplib2
 google-auth-oauthlib
 qdrant-client==1.8.0 # for Qdrant VectorStore
 PyPDF2
+langchain_google_community # For GoogleDriveLoader


### PR DESCRIPTION
We need the GoogleDriveLoader from the new repository (https://github.com/langchain-ai/langchain-google) to load authorized identities. It's not available in the GoogleDriveLoader within the Langchain community.