### PR TITLE
Minor UI fixes

### DIFF
--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -202,7 +202,7 @@ export const FILES_WITH_FINDINGS_TABLE = [
         })),
         dialogTitle: `<div class="flex gap-4 items-center">
           <div>Identities (${item?.authorizedIdentities?.length})</div>
-          <div class="font-12 surface-10-opacity-50 overflow-ellipsis w-400px overflow-hidden" title="${item.fileName}">Document: ${item?.fileName}</div>     
+          <div class="text-none font-12 surface-10-opacity-50 overflow-ellipsis w-400px overflow-hidden" title="${item.fileName}">Document: ${item?.fileName}</div>     
         </div>`,
       }),
     align: "start",

--- a/pebblo/app/routers/local_ui_routers.py
+++ b/pebblo/app/routers/local_ui_routers.py
@@ -16,7 +16,10 @@ local_ui_router_instance.router.add_api_route(
     "/app/", App.app_details, methods=["GET"], response_class=HTMLResponse
 )
 local_ui_router_instance.router.add_api_route(
-    "/safe_retrieval/app/", App.app_details, methods=["GET"], response_class=HTMLResponse
+    "/safe_retrieval/app/",
+    App.app_details,
+    methods=["GET"],
+    response_class=HTMLResponse,
 )
 local_ui_router_instance.router.add_api_route(
     "/report/", App.get_report, methods=["GET"], response_class=FileResponse

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -13,9 +13,13 @@ from pebblo.reports.enums.report_libraries import library_function_mapping
 from pebblo.reports.libs.logger import logger
 
 
-def date_formatter(date_obj):
+def date_formatter(date_obj, show_timezone=True):
     """Converts date string to object and returns formatted string for date (D M Y, H:M)"""
-    return date_obj.strftime("%d %B %Y , %H:%M") + " " + time.localtime().tm_zone
+    date_str = date_obj.strftime("%d %B %Y , %H:%M")
+    if show_timezone:
+        return date_str + " " + time.localtime().tm_zone
+    else:
+        return date_str
 
 
 def get_file_size(size):
@@ -44,11 +48,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         template_loader = jinja2.FileSystemLoader(searchpath=search_path)
         template_env = jinja2.Environment(loader=template_loader)
         template = template_env.get_template(template_name)
-        current_date = (
-            datetime.datetime.now().strftime("%B %d, %Y")
-            + " "
-            + time.localtime().tm_zone
-        )
+        current_date = datetime.datetime.now().strftime("%B %d, %Y")
         load_history_items = []
         findings_details = []
         datastores = []

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -69,7 +69,7 @@
           <div class="surface-10 font-14">Report Summary</div>
           <div class="surface-10-opacity font-12 ml-2">
             Current Load By {{ data.reportSummary.owner }}, {{
-            dateFormatter(data.reportSummary.createdAt) }}
+            dateFormatter(data.reportSummary.createdAt, True) }}
           </div>
         </div>
         <div class="flex inter">
@@ -175,7 +175,7 @@
                   <td colspan="2" class="break-word">{{ item.reportName }}</td>
                   <td class="text-end">{{ item.findings }}</td>
                   <td class="text-end">{{ item.filesWithFindings }}</td>
-                  <td>{{ dateFormatter(item.generatedOn) }}</td>
+                  <td>{{ dateFormatter(item.generatedOn, True) }}</td>
                 </tr>
                 {% endfor %}
               </tbody>
@@ -253,7 +253,8 @@
                       <div class="flex flex-col ml-2">
                         <div class="surface-40 font-12">Created At</div>
                         <div class="surface-10 mt-1">
-                          {{ dateFormatter(data.instanceDetails.createdAt) }}
+                          {{ dateFormatter(data.instanceDetails.createdAt, True)
+                          }}
                         </div>
                       </div>
                     </div>
@@ -276,7 +277,7 @@
                       <div class="divider bg-surface-70"></div>
                       <div class="flex flex-col ml-2">
                         <div class="surface-40 font-12">Path</div>
-                        <div class="surface-10 mt-1">
+                        <div class="surface-10 mt-1 max-w-70 break-all">
                           {{ data.instanceDetails.path }} &nbsp;
                         </div>
                       </div>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -686,7 +686,7 @@
             <span class="medium surface-10 font-13">Report Summary</span>
             <span class="surface-0 font-12 ml-2 normal">
               Current Load By {{ data.reportSummary.owner }}, {{
-              dateFormatter(data.reportSummary.createdAt) }}</span
+              dateFormatter(data.reportSummary.createdAt, True) }}</span
             >
           </div>
           <div class="pr-8 pl-8">
@@ -808,7 +808,7 @@
                     {{ item.filesWithFindings }}
                   </td>
                   <td class="text-end align-cell-left w-300">
-                    {{ dateFormatter(item.generatedOn) }}
+                    {{ dateFormatter(item.generatedOn, True) }}
                   </td>
                 </tr>
                 {% endfor %}
@@ -870,7 +870,7 @@
                   </td>
                   <td>
                     <div class="surface-10 mt-1">
-                      {{ dateFormatter(data.instanceDetails.createdAt) }}
+                      {{ dateFormatter(data.instanceDetails.createdAt, True) }}
                     </div>
                   </td>
                 </tr>
@@ -889,7 +889,7 @@
                     <div class="surface-40 font-12 medium">Path</div>
                   </td>
                   <td>
-                    <div class="surface-10 mt-1">
+                    <div class="surface-10 mt-1 w-70 break-all">
                       {{ data.instanceDetails.path }}
                     </div>
                   </td>

--- a/tests/reports/test_report_generator.py
+++ b/tests/reports/test_report_generator.py
@@ -28,7 +28,7 @@ class TestReportGenerator(unittest.TestCase):
 
     def test_date_formatter(self):
         """Test if date formatter returns correct string"""
-        output_str = date_formatter(self.date_obj)
+        output_str = date_formatter(self.date_obj, True)
         assert output_str == "02 February 2024 , 16:25" + " " + time.localtime().tm_zone
 
     def test_file_size_conversion(self):


### PR DESCRIPTION
Fixes:
1. From identities dialog, disabled capitalize function on document name:
<img width="616" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/1301b983-ea47-40d6-a050-5fcf61d31f12">

2. Removed timezone from date in xhtml2pdf and weasyprint report PDFs:
<img width="470" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/4119e492-cc1a-45cf-99aa-61a3fb9d9f58">

<img width="479" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/8253101e-04aa-47ae-a361-dac4a0177671">

3. Added text wrap to long path names in both reports:
<img width="584" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/37181135-d010-45d8-bbde-86cc268c6ade">
<img width="1088" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/027f967e-8cc7-4348-9063-a61eb337c5a1">



