### PR TITLE
Pebblo redirection and download report URL fix

### DIFF
--- a/pebblo/app/api/redirection_api.py
+++ b/pebblo/app/api/redirection_api.py
@@ -10,4 +10,4 @@ class App:
 
     @staticmethod
     def redirect(request: Request):
-        return f"{request.base_url}/pebblo/"
+        return f"{request.base_url}pebblo/"

--- a/pebblo/app/api/redirection_api.py
+++ b/pebblo/app/api/redirection_api.py
@@ -1,7 +1,5 @@
 from fastapi import APIRouter, Request
 
-from pebblo.app.enums.enums import CacheDir
-
 
 class App:
     """

--- a/pebblo/app/api/redirection_api.py
+++ b/pebblo/app/api/redirection_api.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from pebblo.app.enums.enums import CacheDir
 
@@ -11,5 +11,5 @@ class App:
         self.router = APIRouter()
 
     @staticmethod
-    def redirect():
-        return f"{CacheDir.PROXY.value}/pebblo/"
+    def redirect(request: Request):
+        return f"{request.base_url}/pebblo/"

--- a/pebblo/app/pebblo-ui/index.html
+++ b/pebblo/app/pebblo-ui/index.html
@@ -8,6 +8,10 @@
     <meta http-equiv="Expires" content="-1" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
     <link
       rel="shortcut icon"
       href="{{ url_for('static', path='/static/pebblo-favicon.png') }}"

--- a/pebblo/app/pebblo-ui/src/constants/routesConstant.js
+++ b/pebblo/app/pebblo-ui/src/constants/routesConstant.js
@@ -3,5 +3,5 @@ const SCRIPT_ELEMENT = document.getElementById("main_script");
 export const PROXY = SCRIPT_ELEMENT.dataset["proxy"];
 export const DASHBOARD_ROUTE = PREFIX + "/";
 export const APP_DETAILS_ROUTE = PREFIX + "/app/";
-export const GET_REPORT = `${PROXY}${PREFIX}/report/`;
+export const GET_REPORT = PREFIX + "/report/";
 export const NOT_FOUND_ROUTE = PREFIX + "/not-found/";

--- a/pebblo/app/pebblo-ui/src/constants/routesConstant.js
+++ b/pebblo/app/pebblo-ui/src/constants/routesConstant.js
@@ -1,6 +1,4 @@
 const PREFIX = "/pebblo";
-const SCRIPT_ELEMENT = document.getElementById("main_script");
-export const PROXY = SCRIPT_ELEMENT.dataset["proxy"];
 export const DASHBOARD_ROUTE = PREFIX + "/";
 export const APP_DETAILS_ROUTE = PREFIX + "/app/";
 export const GET_REPORT = PREFIX + "/report/";

--- a/pebblo/app/pebblo-ui/src/services/get.js
+++ b/pebblo/app/pebblo-ui/src/services/get.js
@@ -1,5 +1,6 @@
 export const GET_FILE = (url) => {
-  const data = fetch(url, { responseType: "arraybuffer" })
+  var new_url = window.location.origin + url;
+  const data = fetch(new_url, { responseType: "arraybuffer" })
     .then((res) => {
       return res.blob();
     })

--- a/pebblo/app/pebblo-ui/src/services/get.js
+++ b/pebblo/app/pebblo-ui/src/services/get.js
@@ -1,6 +1,6 @@
-export const GET_FILE = (url) => {
-  var new_url = window.location.origin + url;
-  const data = fetch(new_url, { responseType: "arraybuffer" })
+export const GET_FILE = (apiEndpoint) => {
+  var url = window.location.origin + apiEndpoint;
+  const data = fetch(url, { responseType: "arraybuffer" })
     .then((res) => {
       return res.blob();
     })


### PR DESCRIPTION
Fixes:

1. Fix Pebblo UI '/' redirection to '/pebblo/'
2. Download report removed PROXY while generating the request URL and used window.location.origin + API endpoint instead.