### PR TITLE
Safe retrieval fixes

### DIFF
--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -92,6 +92,21 @@ class Chain(BaseModel):
     model: Optional[AiModel]
 
 
+class RetrievalContext(BaseModel):
+    retrieved_from: str
+    doc: str
+    vector_db: str
+
+
+class RetrievalData(BaseModel):
+    context: List[RetrievalContext]
+    prompt: AiDataModel
+    response: AiDataModel
+    prompt_time: str
+    user: str
+    linked_groups: list[str] = []
+
+
 class AiApp(BaseModel):
     metadata: Metadata
     name: str
@@ -104,6 +119,7 @@ class AiApp(BaseModel):
     pebbloServerVersion: Optional[str]
     pebbloClientVersion: Optional[str]
     chains: Optional[List[Chain]]
+    retrievals: Optional[List[RetrievalData]] = []
 
 
 class Summary(BaseModel):
@@ -184,21 +200,6 @@ class LoaderAppModel(BaseModel):
     findings: list
     documentsWithFindings: list
     dataSource: list
-
-
-class RetrievalContext(BaseModel):
-    retrieved_from: str
-    doc: str
-    vector_db: str
-
-
-class RetrievalData(BaseModel):
-    context: List[RetrievalContext]
-    prompt: AiDataModel
-    response: AiDataModel
-    prompt_time: str
-    user: str
-    linked_groups: list[str] = []
 
 
 class RetrievalAppListDetails(BaseModel):

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -45,7 +45,9 @@ class AppDiscover:
         """
         return datetime.now()
 
-    def _create_ai_apps_model(self, instance_details, chain_details):
+    def _create_ai_apps_model(
+        self, instance_details, chain_details, retrievals_details
+    ):
         """
         Create an AI App Model and return the corresponding model object
         """
@@ -68,7 +70,7 @@ class AppDiscover:
             pebbloServerVersion=get_pebblo_server_version(),
             pebbloClientVersion=self.data.get("plugin_version", ""),
             chains=chain_details,
-            retrievals=self.data.get("retrievals", [])
+            retrievals=retrievals_details,
         )
         logger.debug(
             f"AI_APPS [{self.application_name}]: AiApps Details: {ai_apps_model.dict()}"
@@ -100,17 +102,13 @@ class AppDiscover:
         )
         return instance_details_model
 
-    def _fetch_chain_details(self) -> list[Chain]:
+    def _fetch_chain_details(self, app_metadata) -> list[Chain]:
         """
         Retrieve chain details from input data and return its corresponding model object.
         """
         # TODO: Discussion on the uniqueness of chains is not done yet,
         #  so for now we are appending chain to existing chains in the file for this app.
-        app_metadata = self._read_file(
-            f"{CacheDir.HOME_DIR.value}/"
-            f"{self.application_name}"
-            f"{CacheDir.APPLICATION_METADATA_FILE_PATH.value}"
-        )
+
         chains = list()
 
         if app_metadata:
@@ -149,6 +147,23 @@ class AppDiscover:
 
         logger.debug(f"Application Name [{self.application_name}]: Chains: {chains}")
         return chains
+
+    def _fetch_retrievals_details(self, app_metadata) -> list:
+        """
+        Retrieve existing retrievals details from metadata file and append the new retrieval details
+        """
+
+        retrievals_details = list()
+
+        if app_metadata:
+            retrievals_details = app_metadata.get("retrievals", [])
+            logger.debug(f"Existing retrieval details : {retrievals_details}")
+
+        input_retrievals_details = self.data.get("retrievals", [])
+        logger.debug(f"Input retrievals : {input_retrievals_details}")
+        retrievals_details.extend(input_retrievals_details)
+
+        return retrievals_details
 
     @staticmethod
     def _write_file_content_to_path(file_content, file_path):
@@ -226,6 +241,9 @@ class AppDiscover:
         Process App discovery Request. This handles discovery for loader as well as retrieval type applications.
         """
         lock_file_path = ""
+        chain_details = []
+        retrievals_details = []
+
         try:
             logger.debug("AI App discovery request processing started")
             logger.debug(f"AI_APP [{self.application_name}]: Input Data: {self.data}")
@@ -256,15 +274,24 @@ class AppDiscover:
                 )
                 self._upsert_metadata_file()
 
+                # It's a Retrieval call, Fetching chain & retrievals details
+                app_metadata = self._read_file(file_path=file_path)
+
+                # Get chain details
+                chain_details = self._fetch_chain_details(app_metadata)
+
+                # get retrievals details
+                retrievals_details = self._fetch_retrievals_details(app_metadata)
+
             acquire_lock(lock_file_path)
+
             # Get instance details
             instance_details = self._fetch_runtime_instance_details()
 
-            # Get chain details
-            chain_details = self._fetch_chain_details()
-
             # Create AiApps Model
-            ai_apps = self._create_ai_apps_model(instance_details, chain_details)
+            ai_apps = self._create_ai_apps_model(
+                instance_details, chain_details, retrievals_details
+            )
 
             # Write file to metadata location
             self._write_file_content_to_path(ai_apps, file_path)

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -68,6 +68,7 @@ class AppDiscover:
             pebbloServerVersion=get_pebblo_server_version(),
             pebbloClientVersion=self.data.get("plugin_version", ""),
             chains=chain_details,
+            retrievals=self.data.get("retrievals", [])
         )
         logger.debug(
             f"AI_APPS [{self.application_name}]: AiApps Details: {ai_apps_model.dict()}"

--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -135,13 +135,13 @@ class AppData:
             return
 
         # fetch total retrievals
-        for retrieval in app_metadata_content.get("retrieval", []):
+        for retrieval in app_metadata_content.get("retrievals", []):
             retrieval_data = {"name": app_json.get("name")}
             retrieval_data.update(retrieval)
             self.total_retrievals.append(retrieval_data)
 
         # fetch active users per app
-        active_users = self.get_active_users(app_metadata_content.get("retrieval", []))
+        active_users = self.get_active_users(app_metadata_content.get("retrievals", []))
         self.add_accumulate_active_users(active_users)
 
         # fetch vector dbs per app
@@ -149,12 +149,12 @@ class AppData:
         self.retrieval_vectordbs.extend(vector_dbs)
 
         # fetch documents name per app
-        documents = self.get_all_documents(app_metadata_content.get("retrieval", []))
+        documents = self.get_all_documents(app_metadata_content.get("retrievals", []))
 
         app_details = RetrievalAppListDetails(
             name=app_json.get("name"),
             owner=app_metadata_content.get("owner"),
-            retrievals=app_metadata_content.get("retrieval", []),
+            retrievals=app_metadata_content.get("retrievals", []),
             active_users=list(active_users.keys()),
             vector_dbs=vector_dbs,
             documents=list(documents.keys()),
@@ -334,7 +334,7 @@ class AppData:
         return None, None
 
     def get_retrieval_app_details(self, app_content):
-        retrieval_data = app_content.get("retrieval", [])
+        retrieval_data = app_content.get("retrievals", [])
 
         active_users = self.get_active_users(retrieval_data)
         documents = self.get_all_documents(retrieval_data)
@@ -426,7 +426,7 @@ class AppData:
                 if data.get("linked_groups"):
                     user_groups.extend(data.get("linked_groups"))
             response[user_name] = {
-                "retrieval": user_data,
+                "retrievals": user_data,
                 "last_accessed_time": self.fetch_last_accessed_time(accessed_time),
                 "linked_groups": list(set(user_groups)),
             }
@@ -488,7 +488,7 @@ class AppData:
             for data in user_data:
                 accessed_time.append(parser.parse(data.get("prompt_time")))
             response[user_name] = {
-                "retrieval": user_data,
+                "retrievals": user_data,
                 "last_accessed_time": self.fetch_last_accessed_time(accessed_time),
             }
         return response

--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -359,7 +359,9 @@ class AppData:
         """Adding retrieval data for app listing per users"""
         for user_name, data in active_users.items():
             if user_name in self.retrieval_active_users.keys():
-                self.retrieval_active_users[user_name].extend(data)
+                self.retrieval_active_users[user_name].get("retrievals", []).extend(
+                    data.get("retrievals", [])
+                )
             else:
                 self.retrieval_active_users[user_name] = data
 
@@ -448,7 +450,6 @@ class AppData:
         """
         resp: dict = {}
         sorted_resp: dict = {}
-
         # fetch data wise retrievals
         for data in retrieval_data:
             data_context = data.get("context")

--- a/pebblo/app/service/prompt_service.py
+++ b/pebblo/app/service/prompt_service.py
@@ -151,13 +151,13 @@ class Prompt:
             if not app_metadata_content:
                 app_metadata_content = {
                     "name": self.application_name,
-                    "retrieval": [retrieval_data],
+                    "retrievals": [retrieval_data],
                 }
             else:  # Updating retrieval data to file
-                if "retrieval" in app_metadata_content.keys():
-                    app_metadata_content.get("retrieval").append(retrieval_data)
+                if "retrievals" in app_metadata_content.keys():
+                    app_metadata_content.get("retrievals").append(retrieval_data)
                 else:
-                    app_metadata_content["retrieval"] = [retrieval_data]
+                    app_metadata_content["retrievals"] = [retrieval_data]
 
             # Writing to app_metadata file
             self._write_file_content_to_path(

--- a/tests/app/service/test_discovery.py
+++ b/tests/app/service/test_discovery.py
@@ -113,7 +113,7 @@ def test_fetch_chain_details(discovery):
             "model": {"name": "text-davinci-003", "vendor": "openai"},
         }
     ]
-    output = discovery._fetch_chain_details()
+    output = discovery._fetch_chain_details(app_metadata=None)
     assert output == expected_output
 
 
@@ -209,6 +209,8 @@ def test_create_ai_apps_model(discovery):
                 "model": {"name": "text-davinci-003", "vendor": "openai"},
             }
         ],
+        "retrievals": []
     }
-    output = discovery._create_ai_apps_model(instance_details, chain_details)
+    retrievals_details = []
+    output = discovery._create_ai_apps_model(instance_details, chain_details, retrievals_details)
     assert output == expected_output

--- a/tests/app/service/test_discovery.py
+++ b/tests/app/service/test_discovery.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict
+from typing import List
 from unittest.mock import MagicMock
 
 import pytest
@@ -212,7 +212,7 @@ def test_create_ai_apps_model(discovery):
         ],
         "retrievals": [],
     }
-    retrievals_details: Dict = {}
+    retrievals_details: List = []
     output = discovery._create_ai_apps_model(
         instance_details, chain_details, retrievals_details
     )

--- a/tests/app/service/test_discovery.py
+++ b/tests/app/service/test_discovery.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
@@ -209,8 +210,10 @@ def test_create_ai_apps_model(discovery):
                 "model": {"name": "text-davinci-003", "vendor": "openai"},
             }
         ],
-        "retrievals": []
+        "retrievals": [],
     }
-    retrievals_details = []
-    output = discovery._create_ai_apps_model(instance_details, chain_details, retrievals_details)
+    retrievals_details: Dict = {}
+    output = discovery._create_ai_apps_model(
+        instance_details, chain_details, retrievals_details
+    )
     assert output == expected_output


### PR DESCRIPTION
Below are the fixes:
- Local UI backend : Replaced `retrieval` with `retrievals` in the app metadata file. For consistency of key name to be plural as it's list of retrievals.
- API Change: Upsert discovery details on top of retrieval details.
- Local UI backend : Fix for one error

Testing done:
- Tested with UI locally with latest UI changes.