### PR TITLE
Remove spell check in CI lint pipeline

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,5 +31,4 @@ jobs:
       - name: Pylint
         run: |
           make lint
-          make spell_check
 


### PR DESCRIPTION
Removing `codespell` until we find a way to exclude files (like .js)