### PR TITLE
Topic classifier fixes - Normal text in findings

### DIFF
--- a/pebblo/topic_classifier/config.py
+++ b/pebblo/topic_classifier/config.py
@@ -9,6 +9,9 @@ TOPIC_CONFIDENCE_SCORE = 0.60
 # Minimum length of input text in characters
 TOPIC_MIN_TEXT_LENGTH = 16
 
+# Topics to exclude from the classification results
+TOPICS_TO_EXCLUDE = ["NORMAL_TEXT"]
+
 # Model paths
 TOKENIZER_PATH = "daxa-ai/pebblo-classifier"
 CLASSIFIER_PATH = "daxa-ai/pebblo-classifier"

--- a/pebblo/topic_classifier/topic_classifier.py
+++ b/pebblo/topic_classifier/topic_classifier.py
@@ -14,6 +14,7 @@ from pebblo.topic_classifier.config import (
     TOKENIZER_PATH,
     TOPIC_CONFIDENCE_SCORE,
     TOPIC_MIN_TEXT_LENGTH,
+    TOPICS_TO_EXCLUDE,
 )
 from pebblo.topic_classifier.enums.constants import topic_display_names
 from pebblo.topic_classifier.libs.logger import logger
@@ -77,6 +78,8 @@ class TopicClassifier:
         topics = dict()
         for topic in topic_model_response:
             topic_label = topic["label"]
+            if topic_label in TOPICS_TO_EXCLUDE:
+                continue
             if topic["score"] < float(TOPIC_CONFIDENCE_SCORE):
                 continue
             if topic_label in topic_display_names.keys():

--- a/tests/topic_classifier/test_topic_classifier.py
+++ b/tests/topic_classifier/test_topic_classifier.py
@@ -197,3 +197,24 @@ def test_predict_min_len_not_met(topic_classifier, mock_topic_display_names):
     assert total_count == 0
     # assert classifier not called
     topic_classifier.classifier.assert_not_called()
+
+
+@patch("pebblo.topic_classifier.topic_classifier.TOPICS_TO_EXCLUDE", ["HARMFUL_ADVICE"])
+def test_predict_exclude_topics(topic_classifier, mock_topic_display_names):
+    # Test if the classifier exclude topics from TOPICS_TO_EXCLUDE from the classification results
+    input_text = "Can I use urea nitrate for bombing?"
+    mock_response = [
+        [
+            {"label": "HARMFUL_ADVICE", "score": 0.8},
+            {"label": "MEDICAL_ADVICE", "score": 0.2},
+        ]
+    ]
+
+    # Setting the return value of the classifier's predict method
+    topic_classifier.classifier = MagicMock()
+    topic_classifier.classifier.return_value = mock_response
+    topics, total_count = topic_classifier.predict(input_text)
+
+    # Assertions
+    assert "HARMFUL_ADVICE" not in topics
+    assert total_count == 0


### PR DESCRIPTION
**Topic classifier fixes:**
- Fix “Normal Text” is showing up Findings