### PR TITLE
source_aggr_size renamed to source_aggregate_size in loader/doc API.

### DIFF
--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -79,7 +79,7 @@ class AppLoaderDoc:
         if loader_details.get("source_path_size") is not None:
             source_size = loader_details.get("source_path_size", 0)
         else:
-            source_size = loader_details.get("source_aggr_size", 0)
+            source_size = loader_details.get("source_aggregate_size", 0)
 
         # Checking for same loader details in app details
         if loader_name and source_type:


### PR DESCRIPTION
Before this fix:
![Screenshot 2024-05-02 at 6 22 54 PM](https://github.com/daxa-ai/pebblo/assets/57351398/749c4332-98ee-4ebe-b453-f98b8f7eb92b)

After the fix:
<img width="658" alt="Screenshot 2024-05-02 at 6 51 44 PM" src="https://github.com/daxa-ai/pebblo/assets/57351398/04e30f8f-e99b-4051-ba2d-a4c17b45674c">

This was not giving error because this is not mandatory param, but it is showing size as empty on UI.