### PR TITLE
Word break: all if overflows column width

### DIFF
--- a/pebblo/reports/templates/index.css
+++ b/pebblo/reports/templates/index.css
@@ -605,6 +605,10 @@ body {
   overflow-wrap: break-word;
 }
 
+.break-all {
+  word-break: break-all;
+}
+
 /* Common styles end */
 
 section {

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -126,8 +126,10 @@
                   <td class="text-end">
                     {{ item.findingsEntities|default('-') }}
                   </td>
-                  <td>{{ item.fileOwner|default('-') }}</td>
-                  <td>
+                  <td class="w-120 break-all">
+                    {{ item.fileOwner|default('-') }}
+                  </td>
+                  <td class="break-all">
                     {{ identity_comma_separated(item.authorizedIdentities) }}
                   </td>
                 </tr>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -44,6 +44,12 @@
       .w-120 {
         width: 120px;
       }
+      .w-90px {
+        width: 90px;
+      }
+      .w-160px {
+        width: 160px;
+      }
       .w-70 {
         width: 70%;
       }
@@ -730,10 +736,10 @@
                     Document Name
                   </th>
                   <th class="th-colored normal text-end align-cell-right">
-                    Findings - Topics
+                    Findings- Topics
                   </th>
                   <th class="th-colored normal text-end align-cell-right">
-                    Findings - Entities
+                    Findings- Entities
                   </th>
                   <th class="th-colored normal align-cell-left">Owner</th>
                   <th class="th-colored normal align-cell-left">Identity</th>
@@ -743,16 +749,16 @@
                 {% for item in data.topFindings %}
                 <tr>
                   <td class="break-all">{{ item.fileName|default('-') }}</td>
-                  <td class="text-end w-120 align-cell-right">
+                  <td class="text-end w-90px align-cell-right">
                     {{ item.findingsTopics|default('-') }}
                   </td>
-                  <td class="text-end w-120 align-cell-right">
+                  <td class="text-end w-90px align-cell-right">
                     {{ item.findingsEntities|default('-') }}
                   </td>
-                  <td class="text-end w-120 align-cell-center">
+                  <td class="text-end w-160px break-all align-cell-center">
                     {{ item.fileOwner|default('-') }}
                   </td>
-                  <td>
+                  <td class="text-end break-all">
                     {{ identity_comma_separated(item.authorizedIdentities) }}
                   </td>
                 </tr>


### PR DESCRIPTION
Added work-break: all to columns in findings table:

**weasyprint report PDF:**
<img width="1032" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/d2ef4b21-463a-4867-9607-ff7929587edb">

**xhtml2pdf report PDF:**
<img width="1082" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/b28a9bd5-f004-45c4-b01d-905529746b60">
