### PR TITLE
Handle bubble chart height for last number of finding data

### DIFF
--- a/pebblo/app/pebblo-ui/src/app.js
+++ b/pebblo/app/pebblo-ui/src/app.js
@@ -29,7 +29,7 @@ export function App() {
   return /*html*/ `
        <div class="app">
           ${Header()}
-          <div class="h-full flex flex-col pt-9 pb-9 pl-25 pr-25 gap-3 overflow-hidden">
+          <div class="h-full flex flex-col pt-9 pb-9 pl-25 pr-25 gap-3 overflow-hidden" id="display_pane">
              ${button}
              ${Card(UI)}
           </div>

--- a/pebblo/app/pebblo-ui/src/components/bubbleChart.js
+++ b/pebblo/app/pebblo-ui/src/components/bubbleChart.js
@@ -8,13 +8,16 @@ export const BubbleChart = (props) => {
       document.getElementById("graph-container").offsetWidth || 1000;
     let height = document.getElementById("graph-container").offsetHeight || 250;
     const margin = 1;
+    const parentHeight =
+      document.getElementById("display_pane").offsetHeight || 800;
 
     const color = d3
       .scaleOrdinal()
       .domain(["entity", "topic"])
       .range(["#BAC5FA", "#B2DDF6"]);
 
-    height = data.length * 10 + 200;
+    const nodeHeight = data.length * 10 + 200;
+    height = nodeHeight > parentHeight ? parentHeight - 80 : nodeHeight;
     const names = (d) => d?.label?.split(" ");
 
     const pack = d3


### PR DESCRIPTION
If the findings data had too many findings, the vertical margin of the bubble chart was increased a lot. Added a case to handle such scenarios.

<img width="1260" alt="image" src="https://github.com/daxa-ai/pebblo/assets/36963955/8274eaa6-ceab-49b5-8629-d77b871b43a4">
