### PR TITLE
Fix test pypi pkg naming to include yr.mo.dt.hh.mm

### DIFF
--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: "3.11.x"
     - name: Install pypa/build
       run: |
-        DATE_TIME=$(date +'%d%m%H%M')
+        DATE_TIME=$(date +'%Y.%m.%d.%H%M')
         PROJECT_FILE_PATH=pyproject.toml
         VERSION_FILE=$(grep -m 1 "version =" $PROJECT_FILE_PATH | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
-        VERSION="$VERSION_FILE$DATE_TIME"
+        VERSION="$VERSION_FILE.$DATE_TIME"
         awk -v new_version="$VERSION" '/^version = "/ {gsub(/"[^"]+"/, "\"" new_version "\"")} 1' "$PROJECT_FILE_PATH" > tmpfile && mv tmpfile "$PROJECT_FILE_PATH"
         pip install build
         python -m build --wheel

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: "3.11.x"
     - name: Install pypa/build
       run: |
-        DATE_TIME=$(date +'%Y.%m.%d.%H%M')
+        DATE_TIME=$(date +'%Y%m%d%H%M')
         PROJECT_FILE_PATH=pyproject.toml
         VERSION_FILE=$(grep -m 1 "version =" $PROJECT_FILE_PATH | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
-        VERSION="$VERSION_FILE.$DATE_TIME"
+        VERSION="$VERSION_FILE$DATE_TIME"
         awk -v new_version="$VERSION" '/^version = "/ {gsub(/"[^"]+"/, "\"" new_version "\"")} 1' "$PROJECT_FILE_PATH" > tmpfile && mv tmpfile "$PROJECT_FILE_PATH"
         pip install build
         python -m build --wheel


### PR DESCRIPTION
Change the naming in test-pypi to a format similar to `pebblo-0.1.15.2024.5.6.1819-py3-none-any.whl` 
This fixes the problem where an older dev pkg is considered a latest even if a newer version is pushed to https://test.pypi.org/project/pebblo/#history