### PR TITLE
Pinned python 3.12 version for UTs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
   RunUnitTests:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Few UTs are failing on python 3.12.4. Ref - https://github.com/daxa-ai/pebblo/actions/runs/9609007513/job/26502752534

It is because of the compatibility with pydantic 1.10.4 version with python 3.12.4.

Executed UTs with python 3.12.3 and they are running fine.

In this PR, pinning python version to 3.12.3 untill pydantic version issue is resolved.

Local logs with python 3.12.3:
```
(venv-3.12.3) ➜  pebblo git:(main) ✗ make tests
pytest tests/ --durations=10
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.12.3, pytest-8.0.0, pluggy-1.5.0
rootdir: /Users/shreyasdamle/work/cloud_defense/shreyas-damle/pebblo
plugins: mock-3.12.0, anyio-4.4.0
collected 45 items

tests/app/config/test_config_validation.py .....                                                                                                                                                     [ 11%]
tests/app/service/test_discovery.py ...                                                                                                                                                              [ 17%]
tests/app/service/test_loader_doc.py .......                                                                                                                                                         [ 33%]
tests/app/test_daemon.py .......                                                                                                                                                                     [ 48%]
tests/app/test_prompt_api.py ....                                                                                                                                                                    [ 57%]
tests/app/test_utils.py .                                                                                                                                                                            [ 60%]
tests/entity_classifier/test_entity_classifier.py ..                                                                                                                                                 [ 64%]
tests/reports/test_report_generator.py ....                                                                                                                                                          [ 73%]
tests/reports/test_reports.py ...                                                                                                                                                                    [ 80%]
tests/topic_classifier/test_topic_classifier.py .........                                                                                                                                            [100%]

============================================================================================= warnings summary =============================================================================================
../../pebblo/venv-3.12.3/lib/python3.12/site-packages/huggingface_hub/file_download.py:1132
  /Users/shreyasdamle/work/cloud_defense/pebblo/venv-3.12.3/lib/python3.12/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== slowest 10 durations ===========================================================================================
2.30s setup    tests/app/service/test_loader_doc.py::test_get_datasource_details
2.19s setup    tests/app/service/test_loader_doc.py::test_get_top_n_findings
1.92s setup    tests/app/service/test_loader_doc.py::test_update_app_details
1.89s setup    tests/app/service/test_loader_doc.py::test_get_doc_report_metadata
1.82s setup    tests/app/service/test_loader_doc.py::test_get_finding_details
1.61s setup    tests/app/service/test_loader_doc.py::test_count_files_with_findings
1.61s setup    tests/app/service/test_loader_doc.py::test_create_data_source_findings_summary
0.01s call     tests/app/test_daemon.py::test_root_endpoint

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
====================================================================================== 45 passed, 1 warning in 16.04s ======================================================================================
(venv-3.12.3) ➜
```