### PR TITLE
Added changes for prompt governance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ MYPY_CACHE=.mypy_cache
 lint:
 	ruff check .
 	ruff format . --diff
-	ruff --select I .
+	ruff check --select I .
 	mkdir -p $(MYPY_CACHE) && mypy --install-types --non-interactive $(PYTHON_FILES) --cache-dir $(MYPY_CACHE) --exclude build/ --exclude pebblo_saferetriever --check-untyped-defs || true
 
 spell_check:

--- a/pebblo/app/api/api.py
+++ b/pebblo/app/api/api.py
@@ -30,7 +30,7 @@ class App:
 
     @staticmethod
     def prompt(data: dict):
-        # "/promptgov" API entrypoint
+        # "/prompt" API entrypoint
         prompt_obj = Prompt(data=data)
         response = prompt_obj.process_request()
         return response

--- a/pebblo/app/api/api.py
+++ b/pebblo/app/api/api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from pebblo.app.service.discovery_service import AppDiscover
+from pebblo.app.service.prompt_gov import PromptGov
 from pebblo.app.service.prompt_service import Prompt
 from pebblo.app.service.service import AppLoaderDoc
 
@@ -29,7 +30,14 @@ class App:
 
     @staticmethod
     def prompt(data: dict):
-        # "/prompt" API entrypoint
+        # "/promptgov" API entrypoint
         prompt_obj = Prompt(data=data)
+        response = prompt_obj.process_request()
+        return response
+
+    @staticmethod
+    def promptgov(data: dict):
+        # "/promptgov" API entrypoint
+        prompt_obj = PromptGov(data=data)
         response = prompt_obj.process_request()
         return response

--- a/pebblo/app/routers/routers.py
+++ b/pebblo/app/routers/routers.py
@@ -25,3 +25,10 @@ router_instance.router.add_api_route(
     response_model=dict,
     response_model_exclude_none=True,
 )
+router_instance.router.add_api_route(
+    "/promptgov",
+    App.promptgov,
+    methods=["POST"],
+    response_model=dict,
+    response_model_exclude_none=True,
+)

--- a/pebblo/app/service/prompt_gov.py
+++ b/pebblo/app/service/prompt_gov.py
@@ -1,0 +1,80 @@
+"""
+Module for prompt governance
+"""
+
+import traceback
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from pebblo.app.libs.logger import logger
+from pebblo.app.models.models import AiDataModel
+from pebblo.entity_classifier.entity_classifier import EntityClassifier
+
+
+class PromptGov:
+    """
+    Class for loader doc related task
+    """
+
+    def __init__(self, data):
+        self.input = data
+        self.entity_classifier_obj = EntityClassifier()
+
+    def _get_classifier_response(self):
+        """
+        Processes the input prompt through the entity classifier and anonymizer, and returns
+        the resulting information encapsulated in an AiDataModel object.
+
+        Returns:
+            AiDataModel: An object containing the anonymized document, entities, and their counts.
+        """
+        doc_info = AiDataModel(
+            data=None,
+            entities={},
+            entityCount=0,
+            topics={},
+            topicCount=0,
+        )
+        try:
+            if self.input.get("prompt") is not None:
+                (
+                    entities,
+                    entity_count,
+                    anonymized_doc,
+                ) = self.entity_classifier_obj.presidio_entity_classifier_and_anonymizer(
+                    self.input.get("prompt"),
+                    anonymize_snippets=False,
+                )
+                doc_info.entities = entities
+                doc_info.entityCount = entity_count
+                doc_info.data = anonymized_doc
+                logger.debug(f"Anonymized Doc: {anonymized_doc}")
+            return doc_info
+        except Exception as e:
+            logger.error(f"Get Classifier Response Failed, Exception: {e}")
+            return doc_info
+
+    def process_request(self):
+        """
+        Process Prompt Governance Request
+        """
+        try:
+            logger.info("Prompt Gov request processing started")
+            logger.info(f"text {self.input.get("prompt")}")
+            doc_info = self._get_classifier_response()
+            logger.info(f"output or prompt gov{doc_info.entities}")
+            return {
+                "message": "Prompt Gov Processed Successfully",
+                "entities": doc_info.entities,
+            }
+        except ValidationError as ex:
+            logger.error(
+                f"Error in Prompt Gov API process_request. Error:{traceback.format_exc()}"
+            )
+            raise HTTPException(status_code=400, detail=str(ex))
+        except Exception as ex:
+            logger.error(
+                f"Error in Prompt Gov API process_request. Error:{traceback.format_exc()}"
+            )
+            raise HTTPException(status_code=500, detail=str(ex))

--- a/pebblo_saferetriever/langchain/identity-rag/sharepoint/msgraph_api_auth.py
+++ b/pebblo_saferetriever/langchain/identity-rag/sharepoint/msgraph_api_auth.py
@@ -1,16 +1,18 @@
-from typing import Optional
 import os
-import requests
+from typing import Optional
 
+import requests
 from dotenv import load_dotenv
+
 load_dotenv()
+
 
 class SharepointADHelper:
     def __init__(
         self,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
-        tenant_id: Optional[str] = None
+        tenant_id: Optional[str] = None,
     ):
         self.client_id = client_id or os.environ.get("O365_CLIENT_ID")
         self.client_secret = client_secret or os.environ.get("O365_CLIENT_SECRET")
@@ -21,9 +23,11 @@ class SharepointADHelper:
             )
         self.access_token = self.get_access_token()
         if not self.access_token:
-            raise EnvironmentError("o365 client id/secret or tenant id is invalid."
-                            "Please check the environment variables.")
-        self.headers = { 'Authorization': 'Bearer' + self.access_token }
+            raise EnvironmentError(
+                "o365 client id/secret or tenant id is invalid."
+                "Please check the environment variables."
+            )
+        self.headers = {"Authorization": "Bearer" + self.access_token}
 
     def get_authorized_identities(self, user_id: str):
         """
@@ -38,11 +42,15 @@ class SharepointADHelper:
         user = self._get_users(user_id)
         user_index_id = user.get("id")
         if not user_index_id:
-            print(f"Could not find the user `{user_id}` information in Microsoft Graph API. Not authorized.")
+            print(
+                f"Could not find the user `{user_id}` information in Microsoft Graph API. Not authorized."
+            )
             return [user_id]
         associated_groups = self._get_associated_groups(user_index_id)
         associated_groups_emails = [
-            group.get("mail") for group in associated_groups["value"] if group.get("mail")
+            group.get("mail")
+            for group in associated_groups["value"]
+            if group.get("mail")
         ]
         return associated_groups_emails + [user_id]
 
@@ -92,7 +100,6 @@ class SharepointADHelper:
         else:
             return response.json()
 
-
     def get_access_token(self):
         """
         Retrieves an access token from Microsoft Graph API using client credentials.
@@ -102,14 +109,14 @@ class SharepointADHelper:
             requests.exceptions.HTTPError: If the request to retrieve the access token fails.
         """
         # ToDo: This access token should be cached and refreshed when it expires
-        # It should also be stored in home directory or in a secure location 
+        # It should also be stored in home directory or in a secure location
         url = f"https://login.microsoftonline.com/{self.tenant_id}/oauth2/v2.0/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "scope": "https://graph.microsoft.com/.default"
+            "scope": "https://graph.microsoft.com/.default",
         }
         try:
             response = requests.post(url, headers=headers, data=data, timeout=10)
@@ -119,6 +126,7 @@ class SharepointADHelper:
             return ""
         else:
             return response.json()["access_token"]
+
 
 if __name__ == "__main__":
     pass

--- a/pebblo_saferetriever/langchain/identity-rag/sharepoint/msgraph_sdk_auth.py
+++ b/pebblo_saferetriever/langchain/identity-rag/sharepoint/msgraph_sdk_auth.py
@@ -1,19 +1,20 @@
-from dotenv import load_dotenv
-load_dotenv()
-
 import asyncio
 import os
 from typing import Optional
 
-from msgraph import GraphServiceClient
 from azure.identity import ClientSecretCredential
+from dotenv import load_dotenv
 from kiota_abstractions.api_error import APIError
+from msgraph import GraphServiceClient
+
+load_dotenv()
+
 
 async def get_authorized_identities(
     user_id: str,
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
-    tenant_id: Optional[str] = None
+    tenant_id: Optional[str] = None,
 ):
     client_id = client_id or os.environ.get("O365_CLIENT_ID")
     client_secret = client_secret or os.environ.get("O365_CLIENT_SECRET")
@@ -42,6 +43,6 @@ async def get_authorized_identities(
     ] + [user_id]
     return auth_iden
 
+
 if __name__ == "__main__":
     print(asyncio.run(get_authorized_identities("arpit@daxaai.onmicrosoft.com")))
-

--- a/pebblo_saferetriever/langchain/identity-rag/sharepoint/pebblo_identity_api_rag.py
+++ b/pebblo_saferetriever/langchain/identity-rag/sharepoint/pebblo_identity_api_rag.py
@@ -1,23 +1,20 @@
 # Fill-in OPENAI_API_KEY in .env file in this directory before proceeding
-from dotenv import load_dotenv
-load_dotenv()
-
-import asyncio
 import os
-from msgraph_api_auth import SharepointADHelper
+
+from dotenv import load_dotenv
 from langchain_community.chains import PebbloRetrievalQA
 from langchain_community.chains.pebblo_retrieval.models import (
     AuthContext,
     ChainInput,
 )
-from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_community.document_loaders import SharePointLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
-from langchain_community.document_loaders import SharePointLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
+from msgraph_api_auth import SharepointADHelper
 
-
+load_dotenv()
 
 
 class PebbloIdentityRAG:
@@ -98,25 +95,34 @@ if __name__ == "__main__":
 
     print("Please enter ingestion user details for loading data...")
     app_client_id = input("App client id : ") or os.environ.get("O365_CLIENT_ID")
-    app_client_secret = input("App client secret : ") or os.environ.get("O365_CLIENT_SECRET")
+    app_client_secret = input("App client secret : ") or os.environ.get(
+        "O365_CLIENT_SECRET"
+    )
     tenant_id = input("Tenant id : ") or os.environ.get("O365_TENANT_ID")
-    
-    drive_id = input("Drive id : ") or "b!TVvGZhXfGUuSKMdCgOucz08XRKxsDuVCojWCjzBMN-as9t-EstljQKBl332OMJnI"
+
+    drive_id = (
+        input("Drive id : ")
+        or "b!TVvGZhXfGUuSKMdCgOucz08XRKxsDuVCojWCjzBMN-as9t-EstljQKBl332OMJnI"
+    )
 
     rag_app = PebbloIdentityRAG(
-        drive_id = drive_id, folder_path = "/document", collection_name=input_collection_name
+        drive_id=drive_id,
+        folder_path="/document",
+        collection_name=input_collection_name,
     )
-    
+
     while True:
         print("Please enter end user details below")
-        end_user_email_address = input("User email address : ") or "arpit@daxaai.onmicrosoft.com"
+        end_user_email_address = (
+            input("User email address : ") or "arpit@daxaai.onmicrosoft.com"
+        )
         prompt = input("Please provide the prompt : ") or "tell me about sample.pdf."
         print(f"User: {end_user_email_address}.\nQuery:{prompt}\n")
         authorized_identities = SharepointADHelper(
-                client_id = app_client_id,
-                client_secret = app_client_secret,
-                tenant_id = tenant_id,
-            ).get_authorized_identities(end_user_email_address)
+            client_id=app_client_id,
+            client_secret=app_client_secret,
+            tenant_id=tenant_id,
+        ).get_authorized_identities(end_user_email_address)
         response = rag_app.ask(prompt, end_user_email_address, authorized_identities)
         print(f"Response:\n{response}")
         try:
@@ -129,4 +135,3 @@ if __name__ == "__main__":
             exit(0)
 
         print("\n\n")
-

--- a/pebblo_saferetriever/langchain/identity-rag/sharepoint/pebblo_identity_sdk_rag.py
+++ b/pebblo_saferetriever/langchain/identity-rag/sharepoint/pebblo_identity_sdk_rag.py
@@ -1,23 +1,21 @@
 # Fill-in OPENAI_API_KEY in .env file in this directory before proceeding
-from dotenv import load_dotenv
-load_dotenv()
-
 import asyncio
 import os
-from msgraph_sdk_auth import get_authorized_identities
+
+from dotenv import load_dotenv
 from langchain_community.chains import PebbloRetrievalQA
 from langchain_community.chains.pebblo_retrieval.models import (
     AuthContext,
     ChainInput,
 )
-from langchain_community.document_loaders import UnstructuredFileIOLoader
+from langchain_community.document_loaders import SharePointLoader
 from langchain_community.document_loaders.pebblo import PebbloSafeLoader
 from langchain_community.vectorstores.qdrant import Qdrant
-from langchain_community.document_loaders import SharePointLoader
 from langchain_openai.embeddings import OpenAIEmbeddings
 from langchain_openai.llms import OpenAI
+from msgraph_sdk_auth import get_authorized_identities
 
-
+load_dotenv()
 
 
 class PebbloIdentityRAG:
@@ -98,27 +96,36 @@ if __name__ == "__main__":
 
     print("Please enter ingestion user details for loading data...")
     app_client_id = input("App client id : ") or os.environ.get("O365_CLIENT_ID")
-    app_client_secret = input("App client secret : ") or os.environ.get("O365_CLIENT_SECRET")
+    app_client_secret = input("App client secret : ") or os.environ.get(
+        "O365_CLIENT_SECRET"
+    )
     tenant_id = input("Tenant id : ") or os.environ.get("O365_TENANT_ID")
-    
-    drive_id = input("Drive id : ") or "b!TVvGZhXfGUuSKMdCgOucz08XRKxsDuVCojWCjzBMN-as9t-EstljQKBl332OMJnI"
+
+    drive_id = (
+        input("Drive id : ")
+        or "b!TVvGZhXfGUuSKMdCgOucz08XRKxsDuVCojWCjzBMN-as9t-EstljQKBl332OMJnI"
+    )
 
     rag_app = PebbloIdentityRAG(
-        drive_id = drive_id, folder_path = "/document", collection_name=input_collection_name
+        drive_id=drive_id,
+        folder_path="/document",
+        collection_name=input_collection_name,
     )
     loop = asyncio.get_event_loop()
-    
+
     while True:
         print("Please enter end user details below")
-        end_user_email_address = input("User email address : ") or "arpit@daxaai.onmicrosoft.com"
+        end_user_email_address = (
+            input("User email address : ") or "arpit@daxaai.onmicrosoft.com"
+        )
         prompt = input("Please provide the prompt : ") or "tell me about sample.pdf."
         print(f"User: {end_user_email_address}.\nQuery:{prompt}\n")
         authorized_identities = loop.run_until_complete(
             get_authorized_identities(
                 user_id=end_user_email_address,
-                client_id = app_client_id,
-                client_secret = app_client_secret,
-                tenant_id = tenant_id,
+                client_id=app_client_id,
+                client_secret=app_client_secret,
+                tenant_id=tenant_id,
             )
         )
         response = rag_app.ask(prompt, end_user_email_address, authorized_identities)

--- a/tests/app/service/test_prompt_gov.py
+++ b/tests/app/service/test_prompt_gov.py
@@ -1,0 +1,36 @@
+# test_prompt_gov.py
+from unittest.mock import patch
+
+import pytest
+
+from pebblo.app.service.prompt_gov import PromptGov
+
+
+@pytest.fixture
+def mock_entity_classifier():
+    with patch("pebblo.app.service.prompt_gov.EntityClassifier") as mock:
+        yield mock
+
+
+def test_process_request_success(mock_entity_classifier):
+    mock_entity_classifier_instance = mock_entity_classifier.return_value
+    mock_entity_classifier_instance.presidio_entity_classifier_and_anonymizer.return_value = (
+        {"us-ssn": 1},
+        1,
+        "anonymized document",
+    )
+
+    data = {"prompt": "Sachin's SSN is 222-85-4836"}
+    prompt_gov = PromptGov(data)
+    response = prompt_gov.process_request()
+
+    expected_response = {
+        "message": "Prompt Gov Processed Successfully",
+        "entities": {"us-ssn": 1},
+    }
+
+    assert response == expected_response
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION


This PR introduces functionality to call the /promptgov API from Langchain whenever a prompt is sent. This integration ensures enhanced entity extraction and validation against a deny list to improve prompt governance. Initially, this feature is implemented for Pebblo, with plans to extend it to Daxa in future updates.

### Changes:
**Router Addition:**
Added a new router in routers.py for handling /promptgov API requests.

**API Endpoint:**
Introduced the prompgov function in api.py to facilitate the communication with the /promptgov API.

**Business Logic:**
Implemented the business logic in prompt_gov.py to extract entities using our entity classifier. The extracted entities are then returned for further processing.

**Langchain Integration:**
On the Langchain side, the implementation includes matching extracted entities against a deny list. If any entity from the deny list is found, the prompt is blocked.

**Output :**
<img width="587" alt="Screenshot 2024-07-04 at 11 41 16 AM" src="https://github.com/daxa-ai/pebblo/assets/37294591/08cdfd6e-0020-46fb-9cb3-56b4c527c54e">

<img width="587" alt="Screenshot 2024-07-04 at 11 40 56 AM" src="https://github.com/daxa-ai/pebblo/assets/37294591/8969b301-1804-4de3-95b1-53681384b1f1">
