### PR TITLE
Remove text-capitalise on app names on Pebblo UI

### DIFF
--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -10,7 +10,6 @@ import { Tooltip } from "../components/tooltip.js";
 import { CopyIcon } from "../icons/index.js";
 import { DownloadIcon } from "../icons/index.js";
 import {
-  capitalizeFirstLetter,
   extractTimezone,
   getDifferenceInDays,
   getFileSize,
@@ -246,8 +245,7 @@ export const TABLE_DATA_FOR_APPLICATIONS = [
     label: "Application",
     field: "name",
     align: "start",
-    render: (item) =>
-      `<span class="text-none">${capitalizeFirstLetter(item?.name)}</span>`,
+    render: (item) => `<span class="text-none">${item?.name}</span>`,
   },
   {
     label: "Findings - Total",
@@ -306,9 +304,7 @@ export const TABLE_DATA_FOR_APPLICATIONS_SAFE_RETRIEVAL = [
     align: "start",
     render: (item) => {
       return /*html*/ `<div class="flex flex-col gap-1">
-        <div class="font-13 text-none">${capitalizeFirstLetter(
-          item?.name
-        )}</div>
+        <div class="font-13 text-none">${item?.name}</div>
         <div class="surface-60 font-11">Owner: ${item?.owner}</div>
       </div>`;
     },
@@ -385,8 +381,7 @@ export const TABLE_DATA_FOR_FINDINGS = [
     label: "Application",
     field: "appName",
     align: "start",
-    render: (item) =>
-      `<span class="text-none">${capitalizeFirstLetter(item?.appName)}</span>`,
+    render: (item) => `<span class="text-none">${item?.appName}</span>`,
   },
 ];
 
@@ -451,8 +446,7 @@ export const TABLE_DATA_FOR_FILES_WITH_FINDINGS = [
     label: "Application",
     field: "appName",
     align: "start",
-    render: (item) =>
-      `<span class="text-none">${capitalizeFirstLetter(item?.appName)}</span>`,
+    render: (item) => `<span class="text-none">${item?.appName}</span>`,
   },
   {
     label: "Data Source",
@@ -489,8 +483,7 @@ export const TABLE_DATA_FOR_DATA_SOURCE = [
     label: "Application",
     field: "appName",
     align: "start",
-    render: (item) =>
-      `<span class="text-none">${capitalizeFirstLetter(item?.appName)}</span>`,
+    render: (item) => `<span class="text-none">${item?.appName}</span>`,
   },
 ];
 
@@ -521,8 +514,7 @@ export const TABLE_DATA_FOR_DATA_SOURCE_APP_DETAILS = [
   {
     label: "Application",
     field: "appName",
-    render: () =>
-      `<span class="text-none">${capitalizeFirstLetter(APP_DATA?.name)}</span>`,
+    render: () => `<span class="text-none">${APP_DATA?.name}</span>`,
     align: "start",
   },
 ];

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -620,7 +620,7 @@ const entitiesCountAllApps = APP_DATA?.findings
 export const TAB_PANEL_ARR_FOR_APPLICATIONS_SAFE_LOADER = [
   {
     value: {
-      title: "Application Name",
+      title: "Applications",
       tableCol: TABLE_DATA_FOR_APPLICATIONS,
       tableData: APP_DATA?.appList,
       isDownloadReport: false,
@@ -700,7 +700,7 @@ export const TAB_PANEL_ARR_FOR_APPLICATIONS_SAFE_LOADER = [
 export const TAB_PANEL_ARR_FOR_APPLICATIONS_SAFE_RETRIEVAL = [
   {
     value: {
-      title: "Application Name",
+      title: "Applications",
       tableCol: TABLE_DATA_FOR_APPLICATIONS_SAFE_RETRIEVAL,
       tableData: APP_DATA?.appList,
       isDownloadReport: false,


### PR DESCRIPTION
- Removed text-capitalise on app names on Pebblo UI:

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/4911e7c8-bf3f-43b1-a311-81a867cd470a">
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/77cea7c2-eb8e-4f6b-8a17-b38fab690b04">
<img width="1218" alt="image" src="https://github.com/user-attachments/assets/9ccc263f-3b27-4ac6-9354-8571d6366e07">
<img width="1219" alt="image" src="https://github.com/user-attachments/assets/2ced0280-36b4-4cbf-96c4-2c7ff54513cb">

- Change table heading from "Application Name" to "Applications":

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/071c73e8-322a-4271-ae02-3040fab2ab09">


