### PR TITLE
Pebblo UI : Fix http to https auto upgrade issue

### DIFF
--- a/pebblo/app/pebblo-ui/index.html
+++ b/pebblo/app/pebblo-ui/index.html
@@ -8,10 +8,6 @@
     <meta http-equiv="Expires" content="-1" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="upgrade-insecure-requests"
-    />
     <link
       rel="shortcut icon"
       href="{{ url_for('static', path='/static/pebblo-favicon.png') }}"


### PR DESCRIPTION
Removed the meta tag for Content Security Policy : update-insecure-requests from index.html - which automatically upgrades any **_http_** requests to **_https_** requests.