### PR TITLE
Pinned python-bidi version to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ dependencies = [
   "jinja2>=3.1.3",
   "tqdm",
   "xhtml2pdf==0.2.15",
+  "python-bidi==0.4.2",
   "python-dateutil==2.9.0",
 ]
 


### PR DESCRIPTION
Pinned `python-bidi` version to 0.4.2. It's new version 0.5.0 is creating problem and stopping generating pdf report.
`python-bidi` package is used by xhtml2pdf module.

Error with latest version of python-bidi:
```
No module named 'bidi.algorithm'
```

Tested locally with the pinned version. pdf report is getting generated.

Ref failure result link - https://github.com/daxa-ai/pebblo/actions/runs/10025055958/job/27707821834#step:12:109