### PR TITLE
Fix Dependabot findings in Pebblo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,13 +105,13 @@ classifiers = [  # Optional
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 dependencies = [ 
-  "fastapi==0.109.0",
+  "fastapi==0.109.1",
   "uvicorn==0.25.0",
-  "pydantic==1.10.8",
+  "pydantic==1.10.13",
   "presidio-analyzer==2.2.351",
   "presidio-anonymizer==2.2.351",
   "torch>=2.1.2",
-  "transformers==4.36.2",
+  "transformers==4.38.0",
   "jinja2>=3.1.3",
   "tqdm",
   "xhtml2pdf==0.2.15",


### PR DESCRIPTION
Updated fastapi, pydantic, transformers module versions as per dependabot findings.

Ref link for dependabot run before fixing these - https://github.com/daxa-ai/pebblo/security/dependabot?q=is%3Aopen+manifest%3Apyproject.toml

Verified few applications after version update. Checked Local UI and pdf reports.