### PR TITLE
Updating pebblo version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ name = "pebblo"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.1.17-rc1"  # Required
+version = "0.1.17rc1"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
**Note:** Updating pebblo-version from `0.1.17-rc1` to `0.1.17rc1`, as it was failing UT. 

**Reason:** on `pyproject.toml` version is specified as  `0.1.17-rc1` , but while fetching version of pebblo using `importlib.metadata`  the version is coming as `0.1.17rc1` , as the pebblo version is being created with this name only without `-`. The wheel file is also without `-` -> `pebblo-0.1.17rc1-py3-none-any.whl`