### PR TITLE
Sort Loader apps based on total findings

### DIFF
--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -239,13 +239,15 @@ class AppData:
                         f"[Dashboard]: Error processing app {app_dir}: {err}"
                     )
 
+            # Sort loader apps
+            sorted_loader_apps = self._sort_loader_apps(all_loader_apps)
             logger.debug("[Dashboard]: Preparing loader app response object")
             loader_response = LoaderAppModel(
                 applicationsAtRiskCount=self.loader_apps_at_risk,
                 findingsCount=self.loader_findings,
                 documentsWithFindingsCount=self.loader_files_findings,
                 dataSourceCount=self.loader_data_source,
-                appList=all_loader_apps,
+                appList=sorted_loader_apps,
                 findings=self.loader_findings_list,
                 documentsWithFindings=self.loader_document_with_findings_list,
                 dataSource=self.loader_data_source_list,
@@ -533,6 +535,18 @@ class AppData:
     def sort_retrievals_data(self, retrieval):
         # Sort the list based on the total count in descending order
         sorted_data = sorted(retrieval, key=self._calculate_total_count, reverse=True)
+        return sorted_data
+
+    @staticmethod
+    def _calculate_findings(item):
+        """Calculate total findings(entities + topics)"""
+        return item["topics"] + item["entities"]
+
+    def _sort_loader_apps(self, loader_apps_list: list):
+        """Sort the list based on the findings in descending order"""
+        sorted_data = sorted(
+            loader_apps_list, key=self._calculate_findings, reverse=True
+        )
         return sorted_data
 
     def get_all_documents(self, retrieval_data: list) -> dict:


### PR DESCRIPTION
Loader Apps would be sorted based on total findings in it, as shown in the diagram:

<img width="1199" alt="Screenshot 2024-07-26 at 7 00 20 PM" src="https://github.com/user-attachments/assets/cda78b19-05e1-4355-9aed-35014004d113">
