### PR TITLE
Update client version field in PDF reports and local UI app details page

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/progressBar.js
+++ b/pebblo/app/pebblo-ui/src/components/progressBar.js
@@ -6,7 +6,6 @@ export function ProgressBar(props) {
   if (id) {
     waitForElement(`#inner-${id}`, 1500).then(function () {
       const innerRect = document.getElementById(`inner-${id}`);
-      console.log({ id, innerRect });
       innerRect.style.width = `${progress}%`;
       innerRect.style.backgroundColor = color;
     });

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -50,6 +50,7 @@ export const PORT = window.location.port;
 
 export const SERVER_VERSION = APP_DATA_RESP?.pebbloServerVersion || "";
 export const CLIENT_VERSION = APP_DATA?.clientVersion?.version || "";
+const clientName = APP_DATA?.clientVersion?.name || "";
 
 export const NO_APPLICATIONS_FOUND = APP_DATA
   ? Object.keys(APP_DATA)?.length === 0
@@ -132,7 +133,7 @@ export const APP_DETAILS = [
   },
   {
     label: "Pebblo Client",
-    value: CLIENT_VERSION,
+    value: `${clientName} ${CLIENT_VERSION}`,
   },
   {
     label: "Path",

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -49,7 +49,7 @@ export const APP_DATA =
 export const PORT = window.location.port;
 
 export const SERVER_VERSION = APP_DATA_RESP?.pebbloServerVersion || "";
-export const CLIENT_VERSION = APP_DATA?.pebbloClientVersion || "";
+export const CLIENT_VERSION = APP_DATA?.clientVersion?.version || "";
 
 export const NO_APPLICATIONS_FOUND = APP_DATA
   ? Object.keys(APP_DATA)?.length === 0
@@ -131,7 +131,7 @@ export const APP_DETAILS = [
     value: getFormattedDate(APP_DATA?.instanceDetails?.createdAt, false, false),
   },
   {
-    label: "Pebblo Client Version",
+    label: "Pebblo Client",
     value: CLIENT_VERSION,
   },
   {

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -52,9 +52,13 @@ export const SERVER_VERSION = APP_DATA_RESP?.pebbloServerVersion || "";
 export const CLIENT_VERSION = APP_DATA?.clientVersion?.version || "";
 const CLIENT_NAME = APP_DATA?.clientVersion?.name || "";
 
+const langchainVersion = APP_DATA?.framework?.version
+  ? `${APP_DATA?.framework?.name}: ${APP_DATA?.framework?.version}`
+  : "";
+
 const PEBBLO_CLIENT_VERSION = CLIENT_VERSION
   ? `${CLIENT_NAME} ${CLIENT_VERSION}`
-  : APP_DATA?.pebbloClientVersion;
+  : `Client Version: ${APP_DATA?.pebbloClientVersion}`;
 
 export const NO_APPLICATIONS_FOUND = APP_DATA
   ? Object.keys(APP_DATA)?.length === 0
@@ -137,7 +141,10 @@ export const APP_DETAILS = [
   },
   {
     label: "Pebblo Client",
-    value: PEBBLO_CLIENT_VERSION,
+    value: `<div class="flex flex-col">
+      <div>${PEBBLO_CLIENT_VERSION}</div>
+      <div>${langchainVersion}</div>
+    </div>`,
   },
   {
     label: "Path",

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -50,7 +50,11 @@ export const PORT = window.location.port;
 
 export const SERVER_VERSION = APP_DATA_RESP?.pebbloServerVersion || "";
 export const CLIENT_VERSION = APP_DATA?.clientVersion?.version || "";
-const clientName = APP_DATA?.clientVersion?.name || "";
+const CLIENT_NAME = APP_DATA?.clientVersion?.name || "";
+
+const PEBBLO_CLIENT_VERSION = CLIENT_VERSION
+  ? `${CLIENT_NAME} ${CLIENT_VERSION}`
+  : APP_DATA?.pebbloClientVersion;
 
 export const NO_APPLICATIONS_FOUND = APP_DATA
   ? Object.keys(APP_DATA)?.length === 0
@@ -133,7 +137,7 @@ export const APP_DETAILS = [
   },
   {
     label: "Pebblo Client",
-    value: `${clientName} ${CLIENT_VERSION}`,
+    value: PEBBLO_CLIENT_VERSION,
   },
   {
     label: "Path",

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -63,7 +63,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         findings_count = data["reportSummary"].get("findings", 0)
         clientVersion = ""
         versionObj = data.get("clientVersion", None)
-        if versionObj != None and versionObj["version"] != None:
+        if versionObj is not None and versionObj["version"] is not None:
             clientVersion = (
                 versionObj.get("name", "") + " " + versionObj.get("version", "")
             )

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -62,7 +62,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
             load_history_items = data["loadHistory"]["history"]
         findings_count = data["reportSummary"].get("findings", 0)
         clientVersion = data.get("pebbloClientVersion", "")
-        if "clientVersion" in data and data["clientVersion"]["version"] != "":
+        if data["clientVersion"]:
             versionDetails = data["clientVersion"]
             clientVersion = versionDetails.get("name") + " "  + versionDetails.get("version")
         source_html = template.render(

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -64,7 +64,9 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         clientVersion = data.get("pebbloClientVersion", "")
         if data["clientVersion"]:
             versionDetails = data["clientVersion"]
-            clientVersion = versionDetails.get("name") + " "  + versionDetails.get("version")
+            clientVersion = (
+                versionDetails.get("name") + " " + versionDetails.get("version")
+            )
         source_html = template.render(
             data=data,
             date=current_date,
@@ -76,7 +78,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
             findings_count=findings_count,
             identity_comma_separated=identity_comma_separated,
             topic_entity_mapping=topic_entity_mapping,
-            clientVersion=clientVersion
+            clientVersion=clientVersion,
         )
         pdf_converter = library_function_mapping[renderer]
         status, result = pdf_converter(source_html, output_path, search_path)

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -61,6 +61,10 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         if "loadHistory" in data and "history" in data["loadHistory"]:
             load_history_items = data["loadHistory"]["history"]
         findings_count = data["reportSummary"].get("findings", 0)
+        clientVersion = data.get("pebbloClientVersion", "")
+        if "clientVersion" in data and data["clientVersion"]["version"] != "":
+            versionDetails = data["clientVersion"]
+            clientVersion = versionDetails.get("name") + " "  + versionDetails.get("version")
         source_html = template.render(
             data=data,
             date=current_date,
@@ -72,6 +76,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
             findings_count=findings_count,
             identity_comma_separated=identity_comma_separated,
             topic_entity_mapping=topic_entity_mapping,
+            clientVersion=clientVersion
         )
         pdf_converter = library_function_mapping[renderer]
         status, result = pdf_converter(source_html, output_path, search_path)

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -53,7 +53,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         current_date = datetime.datetime.now().strftime("%B %d, %Y")
         load_history_items = []
         findings_details = []
-        datastores: dict = {}
+        datastores: dict = {}    
         if "dataSources" in data and data["dataSources"]:
             datastores = data["dataSources"][0]
             if "findingsDetails" in datastores:
@@ -61,11 +61,11 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         if "loadHistory" in data and "history" in data["loadHistory"]:
             load_history_items = data["loadHistory"]["history"]
         findings_count = data["reportSummary"].get("findings", 0)
-        clientVersion = data.get("pebbloClientVersion", "")
-        if data.get("clientVersion", {}):
-            versionDetails = data["clientVersion"]
+        clientVersion = ''
+        versionObj = data.get("clientVersion", None)
+        if versionObj != None and versionObj["version"] != None:
             clientVersion = (
-                versionDetails.get("name") + " " + versionDetails.get("version")
+                versionObj.get("name", "") + " " + versionObj.get("version", "")
             )
         source_html = template.render(
             data=data,

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -62,7 +62,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
             load_history_items = data["loadHistory"]["history"]
         findings_count = data["reportSummary"].get("findings", 0)
         clientVersion = data.get("pebbloClientVersion", "")
-        if data["clientVersion"]:
+        if data.get("clientVersion", {}):
             versionDetails = data["clientVersion"]
             clientVersion = (
                 versionDetails.get("name") + " " + versionDetails.get("version")

--- a/pebblo/reports/html_to_pdf_generator/report_generator.py
+++ b/pebblo/reports/html_to_pdf_generator/report_generator.py
@@ -53,7 +53,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         current_date = datetime.datetime.now().strftime("%B %d, %Y")
         load_history_items = []
         findings_details = []
-        datastores: dict = {}    
+        datastores: dict = {}
         if "dataSources" in data and data["dataSources"]:
             datastores = data["dataSources"][0]
             if "findingsDetails" in datastores:
@@ -61,7 +61,7 @@ def convert_html_to_pdf(data, output_path, template_name, search_path, renderer)
         if "loadHistory" in data and "history" in data["loadHistory"]:
             load_history_items = data["loadHistory"]["history"]
         findings_count = data["reportSummary"].get("findings", 0)
-        clientVersion = ''
+        clientVersion = ""
         versionObj = data.get("clientVersion", None)
         if versionObj != None and versionObj["version"] != None:
             clientVersion = (

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -47,7 +47,7 @@
         <div class="font-12 flex">
           <div>Server {{data.pebbloServerVersion|default(" ")}}</div>
           <div class="divider bg-surface-30 mr-1 ml-1"></div>
-          <div>Client {{data.pebbloClientVersion|default(" ")}}</div>
+          <div>Client {{clientVersion|default(" ")}}</div>
         </div>
       </div>
     </section>

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -51,8 +51,6 @@
         <div class="h-1px flex flex-1 bg-surface-30 ml-2 mr-2"></div>
         <div class="font-12 flex">
           <div>Server: {{data.pebbloServerVersion|default(" ")}}</div>
-          <div class="divider bg-surface-30 mr-1 ml-1"></div>
-          <div>Client: {{data.pebbloClientVersion|default(" ")}}</div>
         </div>
       </div>
     </section>

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -45,9 +45,9 @@
         <div class="font-11">By Daxa.ai</div>
         <div class="h-1px flex flex-1 bg-surface-30 ml-2 mr-2"></div>
         <div class="font-12 flex">
-          <div>Server {{data.pebbloServerVersion|default(" ")}}</div>
+          <div>Server: {{data.pebbloServerVersion|default(" ")}}</div>
           <div class="divider bg-surface-30 mr-1 ml-1"></div>
-          <div>Client {{clientVersion|default(" ")}}</div>
+          <div>Client: {{clientVersion|default(" ")}}</div>
         </div>
       </div>
     </section>

--- a/pebblo/reports/templates/weasyprintTemplate.html
+++ b/pebblo/reports/templates/weasyprintTemplate.html
@@ -22,6 +22,11 @@
           <div class="purple-10 inter font-28 mt-2">
             {{data.framework.name|capitalize}} {{data.framework.version}}
           </div>
+          {% if clientVersion %}
+          <div class="purple-10 inter font-18 mt-2">
+            {{clientVersion|default(" ")}}
+          </div>
+          {% endif %}
         </div>
         <div class="mt-11">
           <div class="purple-10 font-13 inter font-thin">
@@ -47,7 +52,7 @@
         <div class="font-12 flex">
           <div>Server: {{data.pebbloServerVersion|default(" ")}}</div>
           <div class="divider bg-surface-30 mr-1 ml-1"></div>
-          <div>Client: {{clientVersion|default(" ")}}</div>
+          <div>Client: {{data.pebbloClientVersion|default(" ")}}</div>
         </div>
       </div>
     </section>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -654,6 +654,11 @@
           <div class="surface-10 inter font-28">
             {{data.framework.name|capitalize}} {{data.framework.version}}
           </div>
+          {% if clientVersion %}
+          <div class="purple-10 inter font-22">
+            {{clientVersion|default(" ")}}
+          </div>
+          {% endif %}
         </div>
         <div class="mt-11">
           <div class="surface-10 font-13 inter font-thin">
@@ -667,7 +672,7 @@
           <span class="font-12">Pebblo By Daxa.ai | </span>
           <span class="font-12 mr-2">
             <span>Server: {{data.pebbloServerVersion|default(" ")}}</span>
-            | <span>Client: {{clientVersion|default(" ")}}</span>
+            | <span>Client: {{data.pebbloClientVersion|default(" ")}}</span>
           </span>
         </div>
       </div>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -666,8 +666,8 @@
         <div class="mt-11 surface-40 font-thin">
           <span class="font-12">Pebblo By Daxa.ai | </span>
           <span class="font-12 mr-2">
-            <span>Server {{data.pebbloServerVersion|default(" ")}}</span> |
-            <span>Client {{clientVersion|default(" ")}}</span>
+            <span>Server: {{data.pebbloServerVersion|default(" ")}}</span>
+            | <span>Client: {{clientVersion|default(" ")}}</span>
           </span>
         </div>
       </div>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -667,7 +667,7 @@
           <span class="font-12">Pebblo By Daxa.ai | </span>
           <span class="font-12 mr-2">
             <span>Server {{data.pebbloServerVersion|default(" ")}}</span> |
-            <span>Client {{data.pebbloClientVersion|default(" ")}}</span>
+            <span>Client {{clientVersion|default(" ")}}</span>
           </span>
         </div>
       </div>

--- a/pebblo/reports/templates/xhtml2pdfTemplate.html
+++ b/pebblo/reports/templates/xhtml2pdfTemplate.html
@@ -672,7 +672,6 @@
           <span class="font-12">Pebblo By Daxa.ai | </span>
           <span class="font-12 mr-2">
             <span>Server: {{data.pebbloServerVersion|default(" ")}}</span>
-            | <span>Client: {{data.pebbloClientVersion|default(" ")}}</span>
           </span>
         </div>
       </div>

--- a/tests/reports/test_report_generator.py
+++ b/tests/reports/test_report_generator.py
@@ -52,7 +52,7 @@ class TestReportGenerator(unittest.TestCase):
             "loadHistory": {"history": "history"},
             "pebbloClientVersion": "client_version",
             "pebbloServerVersion": "server_version",
-            "clientVersion": {},
+            "clientVersion": {"version": None, "name": None},
         }
         output_path = "output_path"
         template_name = "template_name"

--- a/tests/reports/test_report_generator.py
+++ b/tests/reports/test_report_generator.py
@@ -50,6 +50,9 @@ class TestReportGenerator(unittest.TestCase):
             "reportSummary": {"findings": "findings"},
             "dataSources": [{"findingsDetails": "details"}],
             "loadHistory": {"history": "history"},
+            "pebbloClientVersion": "client_version",
+            "pebbloServerVersion": "server_version",
+            "clientVersion": {},
         }
         output_path = "output_path"
         template_name = "template_name"


### PR DESCRIPTION
Update Pebblo Client Version Key:

1. Pebblo Local UI:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/8c072221-e246-42da-9f1a-c5d8f81da28e">

2. Show pebbloClientVersion if client version does not exist (backward compatibility):
<img width="491" alt="image" src="https://github.com/user-attachments/assets/ce3ea411-b4f6-4f99-8d6e-f2108764b282">

3. Reports -  weasyprint report PDF:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/0748499f-07a3-41a6-91b4-5c6e897383dc">

- Show nothing if client version does not exist (backward compatibility): 
<img width="987" alt="image" src="https://github.com/user-attachments/assets/09153273-a869-4468-bd69-34a110541926">

4. Reports - xhtml2pdf report PDF:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/b083342f-9be6-4bf5-9d41-5b33227db151">

- Show nothing if client version does not exist (backward compatibility): 
<img width="725" alt="image" src="https://github.com/user-attachments/assets/a5ef1e6e-187c-41c3-b15c-10b3ec5e737f">






