### PR TITLE
Adding client version to report.json file

### DIFF
--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -242,6 +242,7 @@ class RetrievalAppDetails(BaseModel):
     instanceDetails: Optional[InstanceDetails]
     pebbloServerVersion: Optional[str]
     pebbloClientVersion: Optional[str]
+    clientVersion: Optional[dict]
     total_prompt_with_findings: int = 0
     retrievals: list[RetrievalData] = []
     activeUsers: dict = {}

--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -195,6 +195,7 @@ class ReportModel(BaseModel):
     dataSources: Optional[List[DataSource]]
     pebbloServerVersion: Optional[str]
     pebbloClientVersion: Optional[str]
+    clientVersion: Optional[dict]
 
 
 class LoaderAppListDetails(BaseModel):

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -549,6 +549,7 @@ class LoaderHelper:
             dataSources=data_source_obj_list,
             pebbloServerVersion=get_pebblo_server_version(),
             pebbloClientVersion=self.app_details.get("pluginVersion", ""),
+            clientVersion=self.app_details.get("clientVersion", {}),
         )
         return report_dict.dict()
 

--- a/pebblo/app/service/local_ui_service.py
+++ b/pebblo/app/service/local_ui_service.py
@@ -537,6 +537,7 @@ class AppData:
             instanceDetails=app_content.get("instanceDetails"),
             pebbloServerVersion=app_content.get("pebbloServerVersion"),
             pebbloClientVersion=app_content.get("pebbloClientVersion"),
+            clientVersion=app_content.get("clientVersion"),
             total_prompt_with_findings=prompt_with_findings,
             retrievals=retrieval_data,
             activeUsers=active_users,


### PR DESCRIPTION
To display `client_version` on Pebblo Local UI, added `clientVersion` in model for loader as well as retriever app