### PR TITLE
Changes for confidence score in /loader/doc as well as UI API

### DIFF
--- a/pebblo/app/models/models.py
+++ b/pebblo/app/models/models.py
@@ -26,8 +26,10 @@ class AiDataModel(BaseModel):
     data: Optional[Union[list, str]]
     entityCount: int
     entities: dict
+    entityDetails: Optional[dict]
     topicCount: Optional[int] = None
     topics: Optional[dict] = None
+    topicDetails: Optional[dict]
 
     def dict(self, **kwargs):
         kwargs["exclude_none"] = True
@@ -43,8 +45,10 @@ class AiDocs(BaseModel):
     loaderSourcePath: str
     lastModified: Optional[datetime]
     entityCount: Optional[int]
+    entityDetails: Optional[dict]
     entities: Optional[dict]
     topicCount: Optional[int]
+    topicDetails: Optional[dict]
     topics: Optional[dict]
     authorizedIdentities: list
 
@@ -159,6 +163,8 @@ class TopFindings(BaseModel):
 
 class Snippets(BaseModel):
     snippet: str
+    entityDetails: Optional[dict]
+    topicDetails: Optional[dict]
     sourcePath: str
     fileOwner: str
     authorizedIdentities: list

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -250,8 +250,8 @@ class LoaderHelper:
         source_path = doc.get("sourcePath")
         snippet = Snippets(
             snippet=doc["doc"],
-            entityDetails=doc["entityDetails"],
-            topicDetails=doc["topicDetails"],
+            entityDetails=doc.get("entityDetails", {}),
+            topicDetails=doc.get("topicDetails", {}),
             sourcePath=source_path,
             fileOwner=doc.get("fileOwner", "-"),
             authorizedIdentities=doc.get("authorizedIdentities", []),

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -124,8 +124,10 @@ class LoaderHelper:
             loaderSourcePath=loader_details.get("source_path"),
             lastModified=last_used,
             entityCount=doc_info.entityCount,
+            entityDetails=doc_info.entityDetails,
             entities=doc_info.entities,
             topicCount=doc_info.topicCount,
+            topicDetails=doc_info.topicDetails,
             topics=doc_info.topics,
             authorizedIdentities=doc.get("authorized_identities", []),
         )
@@ -177,8 +179,10 @@ class LoaderHelper:
             data=doc.get("doc", None),
             entities={},
             entityCount=0,
+            entityDetails={},
             topics={},
             topicCount=0,
+            topicDetails={},
         )
         try:
             if doc_info.data:
@@ -196,6 +200,8 @@ class LoaderHelper:
                 )
                 doc_info.topics = topics
                 doc_info.entities = entities
+                doc_info.entityDetails = entity_details
+                doc_info.topicDetails = topic_details
                 doc_info.topicCount = topic_count
                 doc_info.entityCount = entity_count
                 doc_info.data = anonymized_doc
@@ -244,6 +250,8 @@ class LoaderHelper:
         source_path = doc.get("sourcePath")
         snippet = Snippets(
             snippet=doc["doc"],
+            entityDetails=doc["entityDetails"],
+            topicDetails=doc["topicDetails"],
             sourcePath=source_path,
             fileOwner=doc.get("fileOwner", "-"),
             authorizedIdentities=doc.get("authorizedIdentities", []),

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -144,6 +144,8 @@ def test_get_doc_report_metadata(loader_helper):
                     {
                         "authorizedIdentities": [],
                         "snippet": "sample doc",
+                        "entityDetails": {},
+                        "topicDetails": {},
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
                     }
@@ -159,6 +161,8 @@ def test_get_doc_report_metadata(loader_helper):
                 "snippets": [
                     {
                         "authorizedIdentities": [],
+                        "entityDetails": {},
+                        "topicDetails": {},
                         "snippet": "sample doc",
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
@@ -176,6 +180,8 @@ def test_get_doc_report_metadata(loader_helper):
                     {
                         "authorizedIdentities": [],
                         "snippet": "sample doc",
+                        "entityDetails": {},
+                        "topicDetails": {},
                         "sourcePath": "/home/ubuntu/sens_data.csv",
                         "fileOwner": "fileOwner",
                     }
@@ -221,6 +227,8 @@ def test_get_finding_details(loader_helper):
                 {
                     "authorizedIdentities": [],
                     "snippet": "Sample Doc",
+                    "entityDetails": {},
+                    "topicDetails": {},
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
                 }
@@ -237,6 +245,8 @@ def test_get_finding_details(loader_helper):
                 {
                     "authorizedIdentities": [],
                     "snippet": "Sample Doc",
+                    "entityDetails": {},
+                    "topicDetails": {},
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
                 }
@@ -253,6 +263,8 @@ def test_get_finding_details(loader_helper):
                 {
                     "authorizedIdentities": [],
                     "snippet": "Sample Doc",
+                    "entityDetails": {},
+                    "topicDetails": {},
                     "sourcePath": "/home/ubuntu/sens_data.csv",
                     "fileOwner": "fileOwner",
                 }


### PR DESCRIPTION
Attaching one `report.json` file with `entityDetails` as well as `topicDetails` entry
[report.json](https://github.com/user-attachments/files/16578257/report.json)
