### PR TITLE
Pebblo Docs - Hide "Version not actively maintained" note

### DIFF
--- a/docs/gh_pages/docusaurus.config.ts
+++ b/docs/gh_pages/docusaurus.config.ts
@@ -37,6 +37,9 @@ const config: Config = {
               label: "latest",
               path: "",
             },
+            "0.1.17": {
+              banner: "none",
+            },
           },
         },
         blog: false,


### PR DESCRIPTION
Hide the note banner:
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/42be946e-8ed3-4355-8812-a7bfe222b196">
