### PR TITLE
Add confidence score at Snippet level

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/tooltip.js
+++ b/pebblo/app/pebblo-ui/src/components/tooltip.js
@@ -5,10 +5,12 @@
 // }
 
 export function Tooltip(props) {
-  const { children, title, variant = "top", inline } = props;
+  const { children, title, variant = "top", inline, width } = props;
   return /*html*/ `
   <span class="tooltip ${inline ? "tooltip-inline" : ""}">
   <span class="tooltip-content">${children}</span>
-  <span class="tooltip-wrapper tooltip-wrapper-${variant}"><span class="tooltip-title-${variant}">${title}</span></span></span>
+  <span class="tooltip-wrapper tooltip-wrapper-${variant} ${
+    width || ""
+  }"><span class="tooltip-title-${variant}">${title}</span></span></span>
    `;
 }

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -1176,7 +1176,7 @@ dialog::backdrop {
   content: "";
   position: absolute;
   top: -10px;
-  left: 50%;
+  left: 10%;
   margin-left: -5px;
   border-width: 5px;
   border-style: solid;
@@ -1414,4 +1414,8 @@ dialog::backdrop {
 .confidence-score {
   background-color: var(--surface-70);
   font-weight: bold;
+}
+
+.width-max-content {
+  width: 200px;
 }


### PR DESCRIPTION
Add confidence score at snippet level for topics:
<img width="1222" alt="image" src="https://github.com/user-attachments/assets/e20dd627-b15c-4ba1-8b8c-5602c0f25023">

Increase width of tooltip for confidence score:
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/a3521b38-742a-4ba9-aee9-7c5c1b053ec8">

Backward compatibility (Do not show anything if no confidence score if found):
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/eeaf5271-de9b-41ec-b2db-56cdc76f0b6a">


