### PR TITLE
Confidence Score fix to highlight only the entity which is present in the label name

### DIFF
--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -240,6 +240,28 @@ class LoaderHelper:
         self.app_details["report_metadata"] = raw_data
 
     @staticmethod
+    def _create_data_source_findings(data_source_findings):
+        for data in data_source_findings:
+            for snippet in data.get("snippets"):
+                entity_details = {}
+                topic_details = {}
+                if data["labelName"] in snippet.get("entityDetails").keys():
+                    entity_details = {
+                        data["labelName"]: snippet.get("entityDetails")[
+                            data["labelName"]
+                        ]
+                    }
+                elif data["labelName"] in snippet.get("topicDetails").keys():
+                    topic_details = {
+                        data["labelName"]: snippet.get("topicDetails")[
+                            data["labelName"]
+                        ]
+                    }
+                snippet["entityDetails"] = entity_details
+                snippet["topicDetails"] = topic_details
+        return data_source_findings
+
+    @staticmethod
     def _get_finding_details(doc, data_source_findings, entity_type, raw_data):
         """
         Retrieve finding details from data source
@@ -335,6 +357,10 @@ class LoaderHelper:
 
             # Create data source findings summary from data source findings
             data_source_findings_summary = self._create_data_source_findings_summary(
+                data_source_findings
+            )
+
+            data_source_findings = self._create_data_source_findings(
                 data_source_findings
             )
 

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -245,18 +245,20 @@ class LoaderHelper:
             for snippet in data.get("snippets"):
                 entity_details = {}
                 topic_details = {}
-                if data["labelName"] in snippet.get("entityDetails").keys():
-                    entity_details = {
-                        data["labelName"]: snippet.get("entityDetails")[
-                            data["labelName"]
-                        ]
-                    }
-                elif data["labelName"] in snippet.get("topicDetails").keys():
-                    topic_details = {
-                        data["labelName"]: snippet.get("topicDetails")[
-                            data["labelName"]
-                        ]
-                    }
+                if snippet.get("entityDetails"):
+                    if data["labelName"] in snippet.get("entityDetails").keys():
+                        entity_details = {
+                            data["labelName"]: snippet.get("entityDetails")[
+                                data["labelName"]
+                            ]
+                        }
+                if snippet.get("topicDetails"):
+                    if data["labelName"] in snippet.get("topicDetails").keys():
+                        topic_details = {
+                            data["labelName"]: snippet.get("topicDetails")[
+                                data["labelName"]
+                            ]
+                        }
                 snippet["entityDetails"] = entity_details
                 snippet["topicDetails"] = topic_details
         return data_source_findings

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -241,24 +241,31 @@ class LoaderHelper:
 
     @staticmethod
     def _create_data_source_findings(data_source_findings):
+        """
+        This function returns data source findings with entity/topic details based on label i.e, entity/topic name
+        """
         for data in data_source_findings:
             for snippet in data.get("snippets"):
                 entity_details = {}
                 topic_details = {}
-                if snippet.get("entityDetails"):
-                    if data["labelName"] in snippet.get("entityDetails").keys():
-                        entity_details = {
-                            data["labelName"]: snippet.get("entityDetails")[
-                                data["labelName"]
-                            ]
-                        }
-                if snippet.get("topicDetails"):
-                    if data["labelName"] in snippet.get("topicDetails").keys():
-                        topic_details = {
-                            data["labelName"]: snippet.get("topicDetails")[
-                                data["labelName"]
-                            ]
-                        }
+                if (
+                    snippet.get("entityDetails")
+                    and data["labelName"] in snippet.get("entityDetails").keys()
+                ):
+                    entity_details = {
+                        data["labelName"]: snippet.get("entityDetails")[
+                            data["labelName"]
+                        ]
+                    }
+                if (
+                    snippet.get("topicDetails")
+                    and data["labelName"] in snippet.get("topicDetails").keys()
+                ):
+                    topic_details = {
+                        data["labelName"]: snippet.get("topicDetails")[
+                            data["labelName"]
+                        ]
+                    }
                 snippet["entityDetails"] = entity_details
                 snippet["topicDetails"] = topic_details
         return data_source_findings

--- a/tests/app/service/test_loader_doc.py
+++ b/tests/app/service/test_loader_doc.py
@@ -481,6 +481,8 @@ def test_get_datasource_details(loader_helper):
                             "snippet": "Name: YqDvXJuxpH\nEmail: bTDyzanhcB@ujxtd.com\nSSN: 807325214\nAddress: ABUbusMLXRygxzpdPOyL\nCC Expiry: 12/2030\nCredit Card Number: 8048428351930771\nCC Security Code: 644\nIPv4: 147.17.4.121\nIPv6: 58fc: 652d:bf33:a1ab: 1f1b: 4d7d: 8fe:d64d\nPhone: 3542039806",
                             "sourcePath": "/home/ubuntu/sens_data.csv",
                             "fileOwner": "fileOnwer",
+                            "entityDetails": {},
+                            "topicDetails": {},
                         }
                     ],
                 },
@@ -495,6 +497,8 @@ def test_get_datasource_details(loader_helper):
                             "snippet": "Name: YqDvXJuxpH\nEmail: bTDyzanhcB@ujxtd.com\nSSN: 807325214\nAddress: ABUbusMLXRygxzpdPOyL\nCC Expiry: 12/2030\nCredit Card Number: 8048428351930771\nCC Security Code: 644\nIPv4: 147.17.4.121\nIPv6: 58fc: 652d:bf33:a1ab: 1f1b: 4d7d: 8fe:d64d\nPhone: 3542039806",
                             "sourcePath": "/home/ubuntu/sens_data.csv",
                             "fileOwner": "fileOwner",
+                            "entityDetails": {},
+                            "topicDetails": {},
                         }
                     ],
                 },
@@ -509,6 +513,8 @@ def test_get_datasource_details(loader_helper):
                             "snippet": "Name: YqDvXJuxpH\nEmail: bTDyzanhcB@ujxtd.com\nSSN: 807325214\nAddress: ABUbusMLXRygxzpdPOyL\nCC Expiry: 12/2030\nCredit Card Number: 8048428351930771\nCC Security Code: 644\nIPv4: 147.17.4.121\nIPv6: 58fc: 652d:bf33:a1ab: 1f1b: 4d7d: 8fe:d64d\nPhone: 3542039806",
                             "sourcePath": "/home/ubuntu/sens_data.csv",
                             "fileOwner": "fileOwner",
+                            "entityDetails": {},
+                            "topicDetails": {},
                         }
                     ],
                 },


### PR DESCRIPTION
**Issue:** In snippets in Safe Loader app, confidence score was highlighted for all the entities/topics, rather it should only be highlighted for the specific label

**Before**
<img width="1486" alt="Screenshot 2024-08-23 at 13 18 08" src="https://github.com/user-attachments/assets/3b260db1-b3cc-4b40-aac8-cd5843dc8a87">

**After**
<img width="1486" alt="Screenshot 2024-08-23 at 13 06 25" src="https://github.com/user-attachments/assets/e64beee1-cf73-425a-8541-3aee4c131c12">
