### PR TITLE
Fix Data source path overflow issue

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/tab.js
+++ b/pebblo/app/pebblo-ui/src/components/tab.js
@@ -52,7 +52,7 @@ function Tabs(tabsArr, tabPanel) {
   }
   return /*html*/ `
       <div class="flex flex-col">
-        <div class="tabs sticky top-0 flex gap-6">
+        <div class="tabs sticky top-0 flex gap-6 overflow-x-auto">
           ${allTabs}
           <div id="tab_selected"></div> 
         </div>

--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -474,7 +474,7 @@ export const TABLE_DATA_FOR_DATA_SOURCE = [
     render: (item) => /*html*/ `
       <div class="flex flex-col inter text-none">
          <div class="surface-10 font-13">${item.name || "-"}</div>
-         <div class="surface-10-opacity-50 font-12">${
+         <div class="surface-10-opacity-50 font-12 w-400px text-wrap">${
            item?.sourceSize ? getFileSize(item.sourceSize) : "-"
          } | ${item.sourcePath}</div>
       </div>
@@ -506,7 +506,7 @@ export const TABLE_DATA_FOR_DATA_SOURCE_APP_DETAILS = [
     render: (item) => /*html*/ `
       <div class="flex flex-col inter text-none">
          <div class="surface-10 font-13">${item.name || "-"}</div>
-         <div class="surface-10-opacity-50 font-12">${
+         <div class="surface-10-opacity-50 font-12 w-400px text-wrap">${
            item.sourceSize ? getFileSize(item.sourceSize) : ""
          } | ${item.sourcePath}</div>
       </div>

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -149,6 +149,9 @@ svg.icon-success {
 .w-100 {
   width: 100%;
 }
+.w-400px {
+  width: 400px;
+}
 
 /* <----------- DISPLAY PROPERTY -----------> */
 .none {
@@ -1023,6 +1026,9 @@ td.fit {
 .overflow-x-hidden {
   overflow-x: hidden;
 }
+.overflow-x-auto {
+  overflow-x: auto;
+}
 
 .snippet-body:hover {
   background: var(--main);
@@ -1418,4 +1424,9 @@ dialog::backdrop {
 
 .width-max-content {
   width: 200px;
+}
+
+.text-wrap {
+  word-break: break-all;
+  text-wrap: wrap;
 }


### PR DESCRIPTION
Truncated data source path string to wrap onto the next line:

- <img width="1242" alt="image" src="https://github.com/user-attachments/assets/72184355-fde6-4a17-8643-4c9b64ceccbb">
- <img width="1244" alt="image" src="https://github.com/user-attachments/assets/a605ed8c-3c85-4d0c-825e-69340a7b055f">
