### PR TITLE
Fix Snippets Listing Page - Snippets Count issue

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/snippetDetails.js
+++ b/pebblo/app/pebblo-ui/src/components/snippetDetails.js
@@ -131,8 +131,8 @@ export function SnippetDetails(props) {
              KEYWORD_MAPPING[item?.labelName] || item?.labelName
            }</div>
            <div class="surface-10-opacity-50 font-12">Showing ${
-             item?.snippetCount
-           } out of ${item?.findings}</div>
+             item?.snippets?.length
+           } out of ${item?.snippetCount}</div>
          </div>
          ${item?.snippetStrings?.myMap((snipp) => {
            const snippetConfidenceScore = getSnippetConfidenceScore(


### PR DESCRIPTION
Fixed issue: On using the search feature to search for labels, the snippet count was being updated incorrectly.
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/46eb2919-87bf-47a0-8ba0-fd3dcc89e622">
