### PR TITLE
Documentation for storage type

### DIFF
--- a/docs/gh_pages/docs/config.md
+++ b/docs/gh_pages/docs/config.md
@@ -41,6 +41,7 @@ Notes:
 - `anonymizeSnippets`: Flag to anonymize snippets in report. Possible values are 'True' and 'False'. When its value is 'True', snippets in reports will be shown as anonymized and vice versa.
 
 ### Storage
+This is beta feature introduced in 0.1.18.
 - `type`: Specifies storage type to store states of the GenAI applications. Possible values are `file` or `db`.  Default value is `file`. By default SQLite database is used when we set it as `db`.
 - `type` as `file` is deprecated, use `type` as `db`. `file` would not be supported from 0.1.19 release.
 

--- a/docs/gh_pages/docs/config.md
+++ b/docs/gh_pages/docs/config.md
@@ -40,6 +40,10 @@ Notes:
 
 - `anonymizeSnippets`: Flag to anonymize snippets in report. Possible values are 'True' and 'False'. When its value is 'True', snippets in reports will be shown as anonymized and vice versa.
 
+### Storage
+- `type`: Specifies storage type to store states of the GenAI applications. Possible values are `file` or `db`.  Default value is `file`. By default SQLite database is used when we set it as `db`.
+- `type` as `file` is deprecated, use `type` as `db`. `file` would not be supported from 0.1.19 release.
+
 ### Default Configuration
 
 ```yaml
@@ -54,6 +58,8 @@ reports:
   outputDir: ~/.pebblo
 classifier:
   anonymizeSnippets: False
+storage:
+  type: file
 ```
 
 `Note`:

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -54,11 +54,6 @@ class StorageConfig(ConfigValidator):
                 f"Valid values are {valid_storage_types}"
             )
 
-        # Set deprecated warning message for file storage type
-        if storage_type == StorageTypes.FILE.value:
-            deprecate_error = f"DeprecationWarning: '{storage_type}' Storage Type will be deprecated starting from Pebblo version 0.0.19, use '{StorageTypes.DATABASE.value}' instead"
-            print(deprecate_error)
-
         if storage_type == StorageTypes.DATABASE.value:
             db_type = self.config.get("db")
             default_location = self.config.get("location")


### PR DESCRIPTION
Before removing deprecate warning:
```
(venv-3-11) ➜  pebblo git:(shreyas-documentation-changes) ✗ pebblo --config pebblo/app/config/config.yaml
  0%|                                                                                                                                                                                | 0/10[00:00<?, ?it/s]
DeprecationWarning: 'file' Storage Type will be deprecated starting from Pebblo version 0.0.19, use 'db' instead
Pebblo server version 0.1.17 starting ...
Downloading topic, entity classifier models ...
```

After removing deprecate warning:
```
(venv-3-11) ➜  pebblo git:(shreyas-documentation-changes) ✗ pebblo --config pebblo/app/config/config.yaml
Pebblo server version 0.1.17 starting ...
Downloading topic, entity classifier models ...
```