### PR TITLE
Ensure the build module is installed before running build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ clean:
 	find . -name __pycache__ | xargs rm -rf
 
 build: clean
+	# Ensure the build module is installed
+	pip install build
+	# Run the build command
 	python -m build --wheel
 
 install: build


### PR DESCRIPTION
**Description:** 
- Ensure the build module is installed before running the build command.
- Currently, the `make install` command fails if the build module is not installed. We need to install it and rerun the install command manually.
- After this change, when a new Python environment is created, `make install` will be the only command needed to install Pebblo.