### PR TITLE
added changes for github and slack token

### DIFF
--- a/pebblo/app/pebblo-ui/src/constants/keywordMapping.js
+++ b/pebblo/app/pebblo-ui/src/constants/keywordMapping.js
@@ -27,6 +27,7 @@ export const KEYWORD_MAPPING = {
   "iban-code": "IBAN code",
   "us-itin": "US ITIN",
   "github-token": "Github Token",
+  "github-finergrained-token": "Github Finergrained Token",
   "slack-token": "Slack Token",
   "aws-access-key": "AWS Access Key",
   "aws-secret-key": "AWS Secret Key",

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -61,14 +61,14 @@ entity_group_conf_mapping = {
     Entities.US_BANK_NUMBER.value: (0.4, PIIGroups.Financial.value),
     Entities.IBAN_CODE.value: (0.8, PIIGroups.Financial.value),
     # Secret
-    SecretEntities.GITHUB_TOKEN.value: (0.8, PIIGroups.Secrets.value),
+    SecretEntities.GITHUB_TOKEN.value: (0.4, PIIGroups.Secrets.value),
     SecretEntities.SLACK_TOKEN.value: (0.8, PIIGroups.Secrets.value),
     SecretEntities.AWS_ACCESS_KEY.value: (0.45, PIIGroups.Secrets.value),
     SecretEntities.AWS_SECRET_KEY.value: (0.8, PIIGroups.Secrets.value),
     SecretEntities.AZURE_KEY_ID.value: (0.8, PIIGroups.Secrets.value),
     SecretEntities.AZURE_CLIENT_SECRET.value: (0.8, PIIGroups.Secrets.value),
-    SecretEntities.GOOGLE_API_KEY.value: (0.8, PIIGroups.Secrets.value),
-    SecretEntities.GITHUB_FINEGRAINED_TOKEN.value: (0.8, PIIGroups.Secrets.value),
+    SecretEntities.GOOGLE_API_KEY.value: (0.4, PIIGroups.Secrets.value),
+    SecretEntities.GITHUB_FINEGRAINED_TOKEN.value: (0.4, PIIGroups.Secrets.value),
     # Network
     Entities.IP_ADDRESS.value: (0.4, PIIGroups.Network.value),
 }

--- a/pebblo/entity_classifier/utils/config.py
+++ b/pebblo/entity_classifier/utils/config.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 secret_entities_context_mapping = {
     "github-token": ["github", "github_token", "git"],
+    "github-finergrained-token": ["github", "github_token", "git"],
     "slack-token": ["slack", "slack token", "slack_token"],
     "aws-access-key": ["aws_access_key", "aws_key", "access", "id", "api"],
     "aws-secret-key": ["aws_secret_key", "secret"],
@@ -39,6 +40,7 @@ class SecretEntities(Enum):
     AZURE_KEY_ID = "azure-key-id"
     AZURE_CLIENT_SECRET = "azure-client-secret"
     GOOGLE_API_KEY = "google-api-key"
+    GITHUB_FINEGRAINED_TOKEN = "github-finergrained-token"
 
 
 class PIIGroups(Enum):
@@ -66,6 +68,7 @@ entity_group_conf_mapping = {
     SecretEntities.AZURE_KEY_ID.value: (0.8, PIIGroups.Secrets.value),
     SecretEntities.AZURE_CLIENT_SECRET.value: (0.8, PIIGroups.Secrets.value),
     SecretEntities.GOOGLE_API_KEY.value: (0.8, PIIGroups.Secrets.value),
+    SecretEntities.GITHUB_FINEGRAINED_TOKEN.value: (0.8, PIIGroups.Secrets.value),
     # Network
     Entities.IP_ADDRESS.value: (0.4, PIIGroups.Network.value),
 }

--- a/pebblo/entity_classifier/utils/regex_pattern.py
+++ b/pebblo/entity_classifier/utils/regex_pattern.py
@@ -5,13 +5,13 @@ These are all enums related to Regex Patterns.
 """
 
 regex_secrets_patterns = {
-    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255})""",
-    "github-finergrained-token": r"""((?:github_pat)_[a-zA-Z0-9_]{36,255})""",
+    "github-token": r"""\b((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255})\b""",
+    "github-finergrained-token": r"""\b((?:github_pat)_[a-zA-Z0-9_]{36,255})\b""",
     "slack-token": r"""(xoxb|xoxp|xapp|xoxa|xoxr|xoxo|xoxs|xoxe)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*""",
     # "Slack Token V2": r"""xox[baprs]-([0-9a-zA-Z]{10,48})?""",
-    "aws-access-key": r"""((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})""",
+    "aws-access-key": r"""\b((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})\b""",
     "aws-secret-key": r"""\b([A-Za-z0-9+/]{40})[ \r\n'"\x60]""",
     "azure-key-id": r"""(?i)(%s).{0,20}([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})""",
     "azure-client-secret": r"""\b(?i)(%s).{0,20}([a-z0-9_\.\-~]{34})\b""",
-    "google-api-key": r"""AIza[0-9A-Za-z\-_]{35}\b""",
+    "google-api-key": r"""\bAIza[0-9A-Za-z\-_]{35}\b""",
 }

--- a/pebblo/entity_classifier/utils/regex_pattern.py
+++ b/pebblo/entity_classifier/utils/regex_pattern.py
@@ -5,12 +5,12 @@ These are all enums related to Regex Patterns.
 """
 
 regex_secrets_patterns = {
-    "github-token": r"""\b((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255})\b""",
-    "slack-token": r"""(xoxb|xoxp|xapp|xoxa|xoxr)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*""",
+    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr|github_pat)_[a-zA-Z0-9_]{36,120})""",
+    "slack-token": r"""(xoxb|xoxp|xapp|xoxa|xoxr|xoxo|xoxs|xoxe)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*""",
     # "Slack Token V2": r"""xox[baprs]-([0-9a-zA-Z]{10,48})?""",
-    "aws-access-key": r"""\b((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})\b""",
+    "aws-access-key": r"""((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})""",
     "aws-secret-key": r"""\b([A-Za-z0-9+/]{40})[ \r\n'"\x60]""",
     "azure-key-id": r"""(?i)(%s).{0,20}([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})""",
     "azure-client-secret": r"""\b(?i)(%s).{0,20}([a-z0-9_\.\-~]{34})\b""",
-    "google-api-key": r"""(?i)(?:youtube)(?:.|[\n\r]){0,40}\bAIza[0-9A-Za-z\-_]{35}\b""",
+    "google-api-key": r"""AIza[0-9A-Za-z\-_]{35}\b""",
 }

--- a/pebblo/entity_classifier/utils/regex_pattern.py
+++ b/pebblo/entity_classifier/utils/regex_pattern.py
@@ -5,7 +5,7 @@ These are all enums related to Regex Patterns.
 """
 
 regex_secrets_patterns = {
-    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr|github_pat)_[a-zA-Z0-9_]{36,120})""",
+    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr|github_pat)_[a-zA-Z0-9_]{36,255})""",
     "slack-token": r"""(xoxb|xoxp|xapp|xoxa|xoxr|xoxo|xoxs|xoxe)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*""",
     # "Slack Token V2": r"""xox[baprs]-([0-9a-zA-Z]{10,48})?""",
     "aws-access-key": r"""((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})""",

--- a/pebblo/entity_classifier/utils/regex_pattern.py
+++ b/pebblo/entity_classifier/utils/regex_pattern.py
@@ -5,7 +5,8 @@ These are all enums related to Regex Patterns.
 """
 
 regex_secrets_patterns = {
-    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr|github_pat)_[a-zA-Z0-9_]{36,255})""",
+    "github-token": r"""((?:ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,255})""",
+    "github-finergrained-token": r"""((?:github_pat)_[a-zA-Z0-9_]{36,255})""",
     "slack-token": r"""(xoxb|xoxp|xapp|xoxa|xoxr|xoxo|xoxs|xoxe)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*""",
     # "Slack Token V2": r"""xox[baprs]-([0-9a-zA-Z]{10,48})?""",
     "aws-access-key": r"""((?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16})""",

--- a/pebblo/reports/enums/keyword_mapping.py
+++ b/pebblo/reports/enums/keyword_mapping.py
@@ -27,6 +27,7 @@ topic_entity_mapping = {
     "iban-code": "IBAN code",
     "us-itin": "US ITIN",
     "github-token": "Github Token",
+    "github-finergrained-token": "Github Finergrained Token",
     "slack-token": "Slack Token",
     "aws-access-key": "AWS Access Key",
     "aws-secret-key": "AWS Secret Key",


### PR DESCRIPTION
**Added a new pii for Github Fine Grained Token** 
"""\b((?:github_pat)_[a-zA-Z0-9_]{36,255})\b"""

Adding github_pat as mentioned [here](https://github.com/odomojuli/regextokens) and based on test data we created.


**Slack**
Changed from  - """(xoxb|xoxp|xapp|xoxa|xoxr)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*"""
To - """(xoxb|xoxp|xapp|xoxa|xoxr|xoxo|xoxs|xoxe)\-[0-9]{10,13}\-[a-zA-Z0-9\-]*"""

Adding as mentioned [here](https://learn.microsoft.com/en-us/purview/sit-defn-slack-access-token) 


**Google API**
Changed from  - """(?i)(?:youtube)(?:.|[\n\r]){0,40}\bAIza[0-9A-Za-z\-_]{35}\b"""
To  - """\bAIza[0-9A-Za-z\-_]{35}\b
Changing as mentioned [here](https://learn.microsoft.com/en-us/purview/sit-defn-google-api-key) 


Reducing confidence score from 0.8 to 0.4 for 
Github token
Github Finegrained Token 
Google API Key

This is done to support format like 

"Git":"value"
"Pat":"value"
Git:value
Key:value
key-value

Check images 
**With Confidence = 0.8**

<img width="737" alt="Screenshot 2024-08-30 at 5 53 53 PM" src="https://github.com/user-attachments/assets/21451750-b26a-4689-a796-c41cb78fcae1">

**With Confidence =  0.4**

<img width="668" alt="Screenshot 2024-08-30 at 5 47 37 PM" src="https://github.com/user-attachments/assets/e9fd0734-2c91-407d-bf6d-5e15ca40a761">

