### PR TITLE
#515 raise if --config is passed but file does not exist

### DIFF
--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -1,6 +1,6 @@
 import pathlib
 from contextvars import ContextVar
-from typing import Tuple, Union, Optional
+from typing import Optional, Tuple, Union
 
 import yaml
 from pydantic import Field

--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -1,6 +1,6 @@
 import pathlib
 from contextvars import ContextVar
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import yaml
 from pydantic import Field
@@ -68,7 +68,7 @@ var_server_config: ContextVar[Config] = ContextVar("server_config", default=None
 var_server_config_dict: ContextVar[dict] = ContextVar("server_config_dict", default={})
 
 
-def load_config(path: str) -> Tuple[dict, Config]:
+def load_config(path: Optional[str]) -> Tuple[dict, Config]:
     try:
         # If Path does not exist in command, set default config value
         conf_obj = Config(

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -37,7 +37,9 @@ def start():
 
     path = args.config
     if path is not None and not os.path.exists(path):
-        raise FileNotFoundError(f"'--config' was passed but config file '{path}' does not exist.")
+        raise FileNotFoundError(
+            f"'--config' was passed but config file '{path}' does not exist."
+        )
     p_bar = tqdm(range(10))
     config_details, server_config = load_config(path)
     var_server_config_dict.set(config_details)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -3,6 +3,7 @@ This is entry point for Pebblo(Pebblo Server and Local UI)
 """
 
 import argparse
+import os
 import warnings
 
 from tqdm import tqdm
@@ -35,6 +36,8 @@ def start():
         exit(0)
 
     path = args.config
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"'--config' was passed but config file '{path}' does not exist.")
     p_bar = tqdm(range(10))
     config_details, server_config = load_config(path)
     var_server_config_dict.set(config_details)

--- a/pebblo/app/daemon.py
+++ b/pebblo/app/daemon.py
@@ -36,7 +36,7 @@ def start():
         exit(0)
 
     path = args.config
-    if not os.path.exists(path):
+    if path is not None and not os.path.exists(path):
         raise FileNotFoundError(f"'--config' was passed but config file '{path}' does not exist.")
     p_bar = tqdm(range(10))
     config_details, server_config = load_config(path)


### PR DESCRIPTION
Fix for #515. 

Handles case when `--config` is unused -> where https://github.com/daxa-ai/pebblo/blob/f13be94416e60472d86e7fd24a628ec3b1be1d33/pebblo/app/config/config.py#L71C5-L71C16
will take `None` as its `path` argument, and the case where `--config` is passed but is not a valid path -> raises `FileNotFoundError`
