### PR TITLE
Fix the ruff command error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ format_diff: PYTHON_FILES=$(shell git diff --relative= --name-only --diff-filter
 format format_diff:
 	[ "$(PYTHON_FILES)" = "" ] || ruff check $(PYTHON_FILES) --fix
 	[ "$(PYTHON_FILES)" = "" ] || ruff format $(PYTHON_FILES)
-	[ "$(PYTHON_FILES)" = "" ] || ruff --select I --fix $(PYTHON_FILES)
+	[ "$(PYTHON_FILES)" = "" ] || ruff check --select I --fix $(PYTHON_FILES)
 
 ################################################
 # HELP


### PR DESCRIPTION
**Description:**
The old command fails with newer versions of ruff. The new command is backward compatible and works with older(`ruff 0.4.2`) and newer(`ruff 0.6.3`) Ruff versions.


**1. Before and After output for new Ruff version(ruff 0.6.3, New Python 3.9 venv):**

<img width="1167" alt="Screenshot 2024-08-30 at 10 09 05 AM" src="https://github.com/user-attachments/assets/adb527d0-c837-4638-a6fa-83ef793f4104">



**2. Before and After output for older Ruff version (ruff 0.4.2, Existing Python 3.9 venv):**

<img width="1004" alt="Screenshot 2024-08-30 at 10 32 54 AM" src="https://github.com/user-attachments/assets/6f5e5d17-49cd-41f4-9a30-3e2408415812">

