### PR TITLE
Bugfix/#514 move weasyprint dependency check to config validation

### DIFF
--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -1,3 +1,4 @@
+import importlib.util
 import logging
 import os
 import sys
@@ -112,13 +113,9 @@ class ReportsConfig(ConfigValidator):
 
     def validate_optional_weasyprint_dependency(self):
         """Check if WeasyPrint is installed"""
-        try:
-            from weasyprint import CSS, HTML
-        except ImportError:
-            error = """Could not import weasyprint package. Please install weasyprint and Pango to generate 
-            report using weasyprint.
-            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"
-            """
+        if importlib.util.find_spec("weasyprint") is None:
+            error = """Error: `renderer: weasyprint` was specified, but weasyprint was not found.
+            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"""
             self.errors.append(error)
 
     @staticmethod
@@ -152,7 +149,7 @@ def validate_config(config_dict):
         "logging": LoggingConfig,
         "reports": ReportsConfig,
         "classifier": ClassifierConfig,
-        "storage": StorageConfig
+        "storage": StorageConfig,
     }
 
     validation_errors = []

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -152,6 +152,7 @@ def validate_config(config_dict):
         "reports": ReportsConfig,
         "classifier": ClassifierConfig,
         "storage": StorageConfig,
+        "dependency": WeasyPrintDependency
     }
 
     validation_errors = []

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -13,7 +13,20 @@ class ConfigValidator(ABC):
 
     @abstractmethod
     def validate(self):
-        pass
+        raise NotImplementedError()
+
+
+class WeasyPrintDependency(ConfigValidator):
+    def validate(self):
+        """Check if WeasyPrint is installed"""
+        try:
+            from weasyprint import CSS, HTML
+        except ImportError:
+            error = """Could not import weasyprint package. Please install weasyprint and Pango to generate 
+            report using weasyprint.
+            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"
+            """
+            self.errors.append(error)
 
 
 class DaemonConfig(ConfigValidator):

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -16,19 +16,6 @@ class ConfigValidator(ABC):
         raise NotImplementedError()
 
 
-class WeasyPrintDependency(ConfigValidator):
-    def validate(self):
-        """Check if WeasyPrint is installed"""
-        try:
-            from weasyprint import CSS, HTML
-        except ImportError:
-            error = """Could not import weasyprint package. Please install weasyprint and Pango to generate 
-            report using weasyprint.
-            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"
-            """
-            self.errors.append(error)
-
-
 class DaemonConfig(ConfigValidator):
     def validate(self):
         host = self.config.get("host")
@@ -120,6 +107,20 @@ class ReportsConfig(ConfigValidator):
         if not os.path.exists(expand_path(str(cache_dir))):
             os.makedirs(expand_path(str(cache_dir)), exist_ok=True)
 
+        if renderer == "weasyprint":
+            self.validate_optional_weasyprint_dependency()
+
+    def validate_optional_weasyprint_dependency(self):
+        """Check if WeasyPrint is installed"""
+        try:
+            from weasyprint import CSS, HTML
+        except ImportError:
+            error = """Could not import weasyprint package. Please install weasyprint and Pango to generate 
+            report using weasyprint.
+            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"
+            """
+            self.errors.append(error)
+
     @staticmethod
     def validate_input(input_dict):
         deprecate_error = "DeprecationWarning: 'outputDir' in config is deprecated, use 'cacheDir' instead"
@@ -151,8 +152,7 @@ def validate_config(config_dict):
         "logging": LoggingConfig,
         "reports": ReportsConfig,
         "classifier": ClassifierConfig,
-        "storage": StorageConfig,
-        "dependency": WeasyPrintDependency
+        "storage": StorageConfig
     }
 
     validation_errors = []

--- a/pebblo/reports/html_to_pdf_generator/generator_functions.py
+++ b/pebblo/reports/html_to_pdf_generator/generator_functions.py
@@ -17,11 +17,6 @@ def weasyprint_pdf_converter(source_html, output_path, search_path):
             target=output_path, stylesheets=[CSS(search_path + "/index.css")]
         )
         return True, result
-    except ImportError:
-        error = """Could not import weasyprint package. Please install weasyprint and Pango to generate report using weasyprint.
-          Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"
-        """
-        return False, error
     except Exception as e:
         return False, e
 

--- a/tests/app/config/test_config_validation.py
+++ b/tests/app/config/test_config_validation.py
@@ -106,6 +106,19 @@ def test_reports_config_validate(setup_and_teardown):
         "Error: Unsupported renderer 'invalid_renderer' specified in the configuration"
     ]
 
+    # Test with weasyprint renderer
+    config = {
+        "format": "pdf",
+        "renderer": "weasyprint",
+        "cacheDir": "~/.pebblo_test_",
+    }
+    validator = ReportsConfig(config)
+    validator.validate()
+    assert validator.errors == [
+        """Error: `renderer: weasyprint` was specified, but weasyprint was not found.
+            Follow documentation for more details - https://daxa-ai.github.io/pebblo/installation"""
+    ]
+
 
 def test_classifier_config_validate():
     # Test with True value
@@ -171,3 +184,14 @@ def test_validate_config(setup_and_teardown):
     with pytest.raises(SystemExit):
         validate_config(config)
     # If the configuration is invalid, validate_config should raise a SystemExit exception
+
+
+# def test_validate_successful_import():
+#     """Test that validate() does not add an error if import is successful"""
+#     # empty config since this is os dependency
+#     config = {}
+#     validator = WeasyPrintDependency(config)
+#     validator.validate()
+#
+#     # Check that no errors were added
+#     assert len(validator.errors) == 0

--- a/tests/app/config/test_config_validation.py
+++ b/tests/app/config/test_config_validation.py
@@ -184,14 +184,3 @@ def test_validate_config(setup_and_teardown):
     with pytest.raises(SystemExit):
         validate_config(config)
     # If the configuration is invalid, validate_config should raise a SystemExit exception
-
-
-# def test_validate_successful_import():
-#     """Test that validate() does not add an error if import is successful"""
-#     # empty config since this is os dependency
-#     config = {}
-#     validator = WeasyPrintDependency(config)
-#     validator.validate()
-#
-#     # Check that no errors were added
-#     assert len(validator.errors) == 0


### PR DESCRIPTION
fixes #514: 
- moves checks for `weasyprint` to `config_validation.py`
- opts for using `importlib.util.find_spec` to check for package spec, instead of importing