### PR TITLE
Fixed text overflow on snippet details "snippet" string

### DIFF
--- a/pebblo/app/pebblo-ui/src/components/snippetDetails.js
+++ b/pebblo/app/pebblo-ui/src/components/snippetDetails.js
@@ -8,7 +8,7 @@ import { Tooltip } from "./tooltip.js";
 
 function DisplaySnippet(props) {
   const { formattedString } = props;
-  return `<div>
+  return `<div class="word-wrap-break">
       ${formattedString.myMap((item, index) =>
         item?.score
           ? Tooltip({

--- a/pebblo/app/pebblo-ui/static/index.css
+++ b/pebblo/app/pebblo-ui/static/index.css
@@ -1127,6 +1127,10 @@ dialog::backdrop {
   border: 1px solid#D8D9E380;
 }
 
+.word-wrap-break {
+  word-wrap: break-word;
+}
+
 /* TOOLTIP */
 
 .tooltip-wrapper {


### PR DESCRIPTION
Fixed the issue where the snippet string was overflowing from the snippet details table.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/54a965e6-954d-4d1f-b606-9985b98489f1">
