### PR TITLE
Fix sorting on findings-total

### DIFF
--- a/pebblo/app/pebblo-ui/src/constants/constant.js
+++ b/pebblo/app/pebblo-ui/src/constants/constant.js
@@ -262,9 +262,7 @@ export const TABLE_DATA_FOR_APPLICATIONS = [
   {
     label: "Findings - Total",
     field: "total",
-    render: (item) => {
-      return item.topics + item.entities;
-    },
+    render: (item) => item.total,
     align: "end",
   },
   {
@@ -696,12 +694,18 @@ export const TABLE_DATA_FOR_PROMPTS_WITH_FINDINGS_SAFE_RETRIEVAL = [
   },
 ];
 
+const appListing =
+  APP_DATA?.appList?.map((app, index) => ({
+    ...app,
+    total: app?.topics + app?.entities,
+  })) || [];
+
 export const TAB_PANEL_ARR_FOR_APPLICATIONS_SAFE_LOADER = [
   {
     value: {
       title: "Applications",
       tableCol: TABLE_DATA_FOR_APPLICATIONS,
-      tableData: APP_DATA?.appList,
+      tableData: appListing,
       isDownloadReport: false,
       searchField: ["name", "owner"],
       isSorting: true,


### PR DESCRIPTION
Fix sorting on Findings - Total Column in Applications Table:
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/2c39ce5d-5d4d-4114-a239-8de9e88794fd">
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/1453e073-e873-4e75-b95b-897dd15cbd61">
