### PR TITLE
Fixed integration tests

### DIFF
--- a/.github/workflows/integration_run.yml
+++ b/.github/workflows/integration_run.yml
@@ -73,7 +73,7 @@ jobs:
           cat /tmp/logs/pebblo.log
 
       - name: Upload Pebblo App Run Logs as Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Pebblo_Report
           path: |


### PR DESCRIPTION
Integration tests were failing with below reason:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. 
Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

Fixed it through this fix.
Verified by running pipeline on my branch - https://github.com/daxa-ai/pebblo/actions/runs/10825876391