### PR TITLE
Fixing client_version error

### DIFF
--- a/pebblo/app/api/req_models.py
+++ b/pebblo/app/api/req_models.py
@@ -52,7 +52,7 @@ class ReqDiscover(BaseModel):
     framework: Framework
     chains: Optional[List[ChainInfo]] = None
     plugin_version: str
-    client_version: Framework
+    client_version: Optional[Framework] = None
 
 
 class ReqLoaderDoc(BaseModel):

--- a/pebblo/app/models/db_models.py
+++ b/pebblo/app/models/db_models.py
@@ -46,6 +46,7 @@ class AiBaseApp(BaseModel):
     ] = []  # list of policy id, title and other details
     pebbloServerVersion: Optional[str] = None
     pebbloClientVersion: Optional[str] = None
+    clientVersion: Optional[FrameworkInfo] = None
     model_config = ConfigDict(arbitrary_types_allowed=True, use_enum_values=True)
 
 

--- a/pebblo/app/service/discovery/discovery_service.py
+++ b/pebblo/app/service/discovery/discovery_service.py
@@ -72,10 +72,12 @@ class AppDiscover:
         current_time = get_current_time()
 
         metadata = Metadata(createdAt=current_time, modifiedAt=current_time)
-        client_version = FrameworkInfo(
-            name=self.data.get("client_version", {}).get("name"),
-            version=self.data.get("client_version", {}).get("version"),
-        )
+        client_version = None
+        if self.data.get("client_version"):
+            client_version = FrameworkInfo(
+                name=self.data.get("client_version", {}).get("name"),
+                version=self.data.get("client_version", {}).get("version"),
+            )
         ai_app_obj = {
             "metadata": metadata,
             "description": self.data.get("description", "-"),

--- a/pebblo/app/service/discovery_service.py
+++ b/pebblo/app/service/discovery_service.py
@@ -64,10 +64,12 @@ class AppDiscover:
             createdAt=self._get_current_datetime(),
             modifiedAt=self._get_current_datetime(),
         )
-        client_version = FrameworkInfo(
-            name=self.data.get("client_version", {}).get("name"),
-            version=self.data.get("client_version", {}).get("version"),
-        )
+        client_version = None
+        if self.data.get("client_version"):
+            client_version = FrameworkInfo(
+                name=self.data.get("client_version", {}).get("name"),
+                version=self.data.get("client_version", {}).get("version"),
+            )
         ai_apps_model = AiApp(
             metadata=metadata,
             name=self.data.get("name"),


### PR DESCRIPTION
**Issue:**
```
send_discover[local]: 
request url http://localhost:8000/v1/app/discover, 
body b'{"name": "acme-sharepoint-ai-search-loader-app-5-0.1.19qa", "owner": "ACME Corp", "description": "Identity enabled SafeLoader app using Pebblo", "load_id": "911875e8-1251-477e-bf32-00b0b889a613", "runtime": {"type": "desktop", "host": "Sridhars-MacBook-Pro.local", "path": "/Users/sridhar/pebblo/demos/pebblo-identityrag-sharepoint-0.1.17-qa", "ip": "127.0.0.1", "platform": "macOS-14.6.1-arm64-arm-64bit", "os": "Darwin", "os_version": "Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000", "language": "python", "language_version": "3.11.9", "runtime": "Mac OSX"}, "framework": {"name": "langchain", "version": "0.2.32"}, "plugin_version": "0.1.1"}' 
len 701                        
response status 422 
response body {'detail': [{'type': 'missing', 'loc': ['body', 'client_version'], 'msg': 'Field required', 'input': {'name': 'acme-sharepoint-ai-search-loader-app-5-0.1.19qa', 'owner': 'ACME Corp', 'description': 'Identity enabled SafeLoader app using Pebblo', 'load_id': '911875e8-1251-477e-bf32-00b0b889a613', 'runtime': {'type': 'desktop', 'host': 'Sridhars-MacBook-Pro.local', 'path': '/Users/sridhar/pebblo/demos/pebblo-identityrag-sharepoint-0.1.17-qa', 'ip': '127.0.0.1', 'platform': 'macOS-14.6.1-arm64-arm-64bit', 'os': 'Darwin', 'os_version': 'Darwin Kernel Version 23.6.0: Mon Jul 29 21:14:30 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6000', 'language': 'python', 'language_version': '3.11.9', 'runtime': 'Mac OSX'}, 'framework': {'name': 'langchain', 'version': '0.2.32'}, 'plugin_version': '0.1.1'}, 'url': '[https://errors.pydantic.dev/2.8/v/missing'}]}](https://errors.pydantic.dev/2.8/v/missing'%7D]%7D)
WARNING:langchain_community.document_loaders.pebblo:Received unexpected HTTP response code:                            422
```

**Changes:**

- Updated `client_version` as Optional filed in discover API to support backward compatibility.
- Also, `client_version` was not coming in /app/discovery Response for DB, added to AiBase Model