### PR TITLE
Add Ruff sort imports command to the format_diff target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ format: PYTHON_FILES=.
 format_diff: PYTHON_FILES=$(shell git diff --relative= --name-only --diff-filter=d main '*.py' '*.ipynb')
 
 format format_diff:
+	[ "$(PYTHON_FILES)" = "" ] || ruff check --select I $(PYTHON_FILES) --fix
 	[ "$(PYTHON_FILES)" = "" ] || ruff check $(PYTHON_FILES) --fix
 	[ "$(PYTHON_FILES)" = "" ] || ruff format $(PYTHON_FILES)
 


### PR DESCRIPTION
Currently, the Ruff formatter does not sort imports. We need to sort imports by calling the Ruff linter.

Ref: [https://docs.astral.sh/ruff/formatter/#sorting-imports](https://docs.astral.sh/ruff/formatter/#sorting-imports)