### PR TITLE
Adding anonymize_snippet as a input filed in /loader/doc API

### DIFF
--- a/pebblo/app/api/req_models.py
+++ b/pebblo/app/api/req_models.py
@@ -66,6 +66,7 @@ class ReqLoaderDoc(BaseModel):
     source_owner: str
     classifier_location: str
     classifier_mode: Optional[str] = None
+    anonymize_snippets: Optional[bool] = None
 
 
 class Context(BaseModel):

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -94,14 +94,14 @@ class LoaderHelper:
 
     @staticmethod
     def _update_raw_data(
-        raw_data: dict,
-        loader_source_snippets: dict,
-        total_findings: int,
-        findings_entities: int,
-        findings_topics: int,
-        snippet_count: int,
-        file_count: int,
-        data_source_findings: dict,
+        raw_data,
+        loader_source_snippets,
+        total_findings,
+        findings_entities,
+        findings_topics,
+        snippet_count,
+        file_count,
+        data_source_findings,
     ):
         """
         Reassigning raw data
@@ -144,7 +144,7 @@ class LoaderHelper:
         return doc_model.model_dump()
 
     @staticmethod
-    def _get_top_n_findings(raw_data: dict) -> list:
+    def _get_top_n_findings(raw_data):
         """
         Return top N findings from all findings
         """
@@ -228,7 +228,7 @@ class LoaderHelper:
             logger.error(f"Get Classifier Response Failed, Exception: {e}")
             return doc_info
 
-    def _update_app_details(self, raw_data: dict, ai_app_docs: list):
+    def _update_app_details(self, raw_data, ai_app_docs):
         """
         Updating ai app details loader source files
         """
@@ -258,7 +258,7 @@ class LoaderHelper:
         self.app_details["report_metadata"] = raw_data
 
     @staticmethod
-    def _create_data_source_findings(data_source_findings: list) -> list:
+    def _create_data_source_findings(data_source_findings):
         """
         This function returns data source findings with entity/topic details based on label i.e, entity/topic name
         """
@@ -289,9 +289,7 @@ class LoaderHelper:
         return data_source_findings
 
     @staticmethod
-    def _get_finding_details(
-        doc: dict, data_source_findings: dict, entity_type: str, raw_data: dict
-    ):
+    def _get_finding_details(doc, data_source_findings, entity_type, raw_data):
         """
         Retrieve finding details from data source
         """
@@ -362,7 +360,7 @@ class LoaderHelper:
                 else:
                     data_source_findings[label_name]["snippets"] = []
 
-    def _get_data_source_details(self, raw_data: dict) -> list:
+    def _get_data_source_details(self, raw_data):
         """
         Create data source findings details and data source findings summary
         """
@@ -407,7 +405,7 @@ class LoaderHelper:
         return data_source_obj_list
 
     @staticmethod
-    def _create_data_source_findings_summary(data_source_findings: list) -> list:
+    def _create_data_source_findings_summary(data_source_findings):
         """
         Creating data source findings summary and return it findings summary list
         """
@@ -432,9 +430,7 @@ class LoaderHelper:
 
         return data_source_findings_summary
 
-    def _create_report_summary(
-        self, raw_data: dict, files_with_findings_count: int
-    ) -> Summary:
+    def _create_report_summary(self, raw_data, files_with_findings_count):
         """
         Return report summary object
         """
@@ -451,7 +447,7 @@ class LoaderHelper:
         )
         return report_summary
 
-    def _get_load_history(self) -> dict:
+    def _get_load_history(self):
         """
         Retrieve previous runs details and create load history and return
         """
@@ -517,7 +513,7 @@ class LoaderHelper:
             load_history["moreReportsPath"] = more_report_full_path
         return load_history
 
-    def _get_doc_report_metadata(self, doc: dict, raw_data: dict) -> dict:
+    def _get_doc_report_metadata(self, doc, raw_data):
         """
         Retrieve metadata from the document, update the raw data,
         and then return the updated raw data.
@@ -587,7 +583,7 @@ class LoaderHelper:
         )
         return raw_data
 
-    def _generate_final_report(self, raw_data: dict) -> dict:
+    def _generate_final_report(self, raw_data):
         """
         Aggregating all input, processing the data, and generating the final report
         """
@@ -625,7 +621,7 @@ class LoaderHelper:
         )
         return report_dict.model_dump()
 
-    def process_docs_and_generate_report(self) -> (dict, dict):
+    def process_docs_and_generate_report(self):
         """
         Processing the doc and aggregate the report data
         """

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -7,7 +7,7 @@ import os.path
 from datetime import datetime
 
 from pebblo.app.enums.common import ClassificationMode
-from pebblo.app.enums.enums import CacheDir, ClassifierConstants, ReportConstants
+from pebblo.app.enums.enums import CacheDir, ReportConstants
 from pebblo.app.models.models import (
     AiDataModel,
     AiDocs,
@@ -37,12 +37,20 @@ class LoaderHelper:
     Class for loader doc related task
     """
 
-    def __init__(self, app_details, data, load_id, classifier_mode):
+    def __init__(
+        self,
+        app_details,
+        data,
+        load_id,
+        classifier_mode="all",
+        anonymize_snippets=False,
+    ):
         self.app_details = app_details
         self.data = data
         self.load_id = load_id
         self.loader_mapper = {}
         self.classifier_mode = classifier_mode
+        self.anonymize_snippets = anonymize_snippets
         self.entity_classifier_obj = EntityClassifier()
 
     # Initialization
@@ -209,7 +217,7 @@ class LoaderHelper:
                         entity_details,
                     ) = self.entity_classifier_obj.presidio_entity_classifier_and_anonymizer(
                         doc_info.data,
-                        anonymize_snippets=ClassifierConstants.anonymize_snippets.value,
+                        anonymize_snippets=self.anonymize_snippets,
                     )
                     doc_info.entities = entities
                     doc_info.entityDetails = entity_details

--- a/pebblo/app/service/doc_helper.py
+++ b/pebblo/app/service/doc_helper.py
@@ -39,11 +39,11 @@ class LoaderHelper:
 
     def __init__(
         self,
-        app_details,
-        data,
-        load_id,
-        classifier_mode="all",
-        anonymize_snippets=False,
+        app_details: dict,
+        data: dict,
+        load_id: str,
+        classifier_mode: str = "all",
+        anonymize_snippets: bool = False,
     ):
         self.app_details = app_details
         self.data = data
@@ -54,7 +54,7 @@ class LoaderHelper:
         self.entity_classifier_obj = EntityClassifier()
 
     # Initialization
-    def _initialize_raw_data(self):
+    def _initialize_raw_data(self) -> dict:
         """
         Initializing raw data and return as dict object
         """
@@ -77,7 +77,7 @@ class LoaderHelper:
         return raw_data
 
     @staticmethod
-    def _fetch_variables(raw_data):
+    def _fetch_variables(raw_data: dict):
         """
         Return list of variable's
         """
@@ -94,14 +94,14 @@ class LoaderHelper:
 
     @staticmethod
     def _update_raw_data(
-        raw_data,
-        loader_source_snippets,
-        total_findings,
-        findings_entities,
-        findings_topics,
-        snippet_count,
-        file_count,
-        data_source_findings,
+        raw_data: dict,
+        loader_source_snippets: dict,
+        total_findings: int,
+        findings_entities: int,
+        findings_topics: int,
+        snippet_count: int,
+        file_count: int,
+        data_source_findings: dict,
     ):
         """
         Reassigning raw data
@@ -119,7 +119,7 @@ class LoaderHelper:
         )
 
     # Model Creation
-    def _create_doc_model(self, doc, doc_info):
+    def _create_doc_model(self, doc: dict, doc_info: AiDataModel) -> dict:
         """
         Create doc model and return its object
         """
@@ -144,7 +144,7 @@ class LoaderHelper:
         return doc_model.model_dump()
 
     @staticmethod
-    def _get_top_n_findings(raw_data):
+    def _get_top_n_findings(raw_data: dict) -> list:
         """
         Return top N findings from all findings
         """
@@ -171,7 +171,7 @@ class LoaderHelper:
         ]
         return top_n_findings
 
-    def _count_files_with_findings(self):
+    def _count_files_with_findings(self) -> int:
         """
         Return the count of files that have associated findings.
         """
@@ -184,7 +184,7 @@ class LoaderHelper:
                     files_with_findings_count += 1
         return files_with_findings_count
 
-    def _get_classifier_response(self, doc):
+    def _get_classifier_response(self, doc: dict) -> AiDataModel:
         doc_info = AiDataModel(
             data=doc.get("doc", None),
             entities={},
@@ -228,7 +228,7 @@ class LoaderHelper:
             logger.error(f"Get Classifier Response Failed, Exception: {e}")
             return doc_info
 
-    def _update_app_details(self, raw_data, ai_app_docs):
+    def _update_app_details(self, raw_data: dict, ai_app_docs: list):
         """
         Updating ai app details loader source files
         """
@@ -258,7 +258,7 @@ class LoaderHelper:
         self.app_details["report_metadata"] = raw_data
 
     @staticmethod
-    def _create_data_source_findings(data_source_findings):
+    def _create_data_source_findings(data_source_findings: list) -> list:
         """
         This function returns data source findings with entity/topic details based on label i.e, entity/topic name
         """
@@ -289,7 +289,9 @@ class LoaderHelper:
         return data_source_findings
 
     @staticmethod
-    def _get_finding_details(doc, data_source_findings, entity_type, raw_data):
+    def _get_finding_details(
+        doc: dict, data_source_findings: dict, entity_type: str, raw_data: dict
+    ):
         """
         Retrieve finding details from data source
         """
@@ -360,7 +362,7 @@ class LoaderHelper:
                 else:
                     data_source_findings[label_name]["snippets"] = []
 
-    def _get_data_source_details(self, raw_data):
+    def _get_data_source_details(self, raw_data: dict) -> list:
         """
         Create data source findings details and data source findings summary
         """
@@ -405,7 +407,7 @@ class LoaderHelper:
         return data_source_obj_list
 
     @staticmethod
-    def _create_data_source_findings_summary(data_source_findings):
+    def _create_data_source_findings_summary(data_source_findings: list) -> list:
         """
         Creating data source findings summary and return it findings summary list
         """
@@ -430,7 +432,9 @@ class LoaderHelper:
 
         return data_source_findings_summary
 
-    def _create_report_summary(self, raw_data, files_with_findings_count):
+    def _create_report_summary(
+        self, raw_data: dict, files_with_findings_count: int
+    ) -> Summary:
         """
         Return report summary object
         """
@@ -447,7 +451,7 @@ class LoaderHelper:
         )
         return report_summary
 
-    def _get_load_history(self):
+    def _get_load_history(self) -> dict:
         """
         Retrieve previous runs details and create load history and return
         """
@@ -513,7 +517,7 @@ class LoaderHelper:
             load_history["moreReportsPath"] = more_report_full_path
         return load_history
 
-    def _get_doc_report_metadata(self, doc, raw_data):
+    def _get_doc_report_metadata(self, doc: dict, raw_data: dict) -> dict:
         """
         Retrieve metadata from the document, update the raw data,
         and then return the updated raw data.
@@ -583,7 +587,7 @@ class LoaderHelper:
         )
         return raw_data
 
-    def _generate_final_report(self, raw_data):
+    def _generate_final_report(self, raw_data: dict) -> dict:
         """
         Aggregating all input, processing the data, and generating the final report
         """
@@ -621,7 +625,7 @@ class LoaderHelper:
         )
         return report_dict.model_dump()
 
-    def process_docs_and_generate_report(self):
+    def process_docs_and_generate_report(self) -> (dict, dict):
         """
         Processing the doc and aggregate the report data
         """

--- a/pebblo/app/service/loader/loader_doc_service.py
+++ b/pebblo/app/service/loader/loader_doc_service.py
@@ -47,8 +47,8 @@ class AppLoaderDoc:
         self.db = SQLiteClient()
         self.data = data
         self.app_name = data.get("name")
-        self._set_classifier_mode(data)
-        self._set_anonymize_snippets(data)
+        self._set_classifier_mode()
+        self._set_anonymize_snippets()
 
     @staticmethod
     def _create_return_response(message, output=None, status_code=200):
@@ -284,48 +284,34 @@ class AppLoaderDoc:
         logger.debug("Data Source has been created successfully.")
         return data_source_obj.data
 
-    def _set_classifier_mode(self, data: dict):
+    def _set_classifier_mode(self):
         """
         This function defines the value of the classifier_mode: if it is included in the API request,
         it will be used; otherwise, the value will be taken from the config.
         """
-        if not data.get("classifier_mode"):
+        if not self.data.get("classifier_mode"):
             self.classifier_mode = config_details.get("classifier", {}).get(
                 "mode", ClassificationMode.ALL.value
             )
         else:
-            self.classifier_mode = data.get("classifier_mode")
+            self.classifier_mode = self.data.get("classifier_mode")
 
-    def _set_anonymize_snippets(self, data: dict):
+    def _set_anonymize_snippets(self):
         """
         This function defines the value of the anonymize_snippets: if it is included in the API request,
         it will be used; otherwise, the value will be taken from the config.
         """
-        if not data.get("anonymize_snippets"):
+        if not self.data.get("anonymize_snippets"):
             self.anonymize_snippets = config_details.get("classifier", {}).get(
                 "anonymizeSnippets", False
             )
         else:
-            self.anonymize_snippets = data.get("anonymize_snippets")
+            self.anonymize_snippets = self.data.get("anonymize_snippets")
 
     @timeit
     def process_request(self, data):
         try:
             self._initialize_data(data)
-
-            if not self.data.get("classifier_mode"):
-                self.classifier_mode = config_details.get("classifier", {}).get(
-                    "mode", ClassificationMode.ALL.value
-                )
-            else:
-                self.classifier_mode = self.data.get("classifier_mode")
-
-            if not data.get("anonymize_snippets"):
-                self.anonymize_snippets = config_details.get("classifier", {}).get(
-                    "anonymizeSnippets", False
-                )
-            else:
-                self.anonymize_snippets = data.get("anonymize_snippets")
 
             # create session
             self.db.create_session()

--- a/pebblo/app/service/loader/loader_doc_service.py
+++ b/pebblo/app/service/loader/loader_doc_service.py
@@ -5,7 +5,7 @@ from os import makedirs, path
 
 from pebblo.app.config.config import var_server_config_dict
 from pebblo.app.enums.common import ClassificationMode
-from pebblo.app.enums.enums import ApplicationTypes, CacheDir, ClassifierConstants
+from pebblo.app.enums.enums import ApplicationTypes, CacheDir
 from pebblo.app.libs.responses import PebbloJsonResponse
 from pebblo.app.models.db_models import (
     AiDataModel,
@@ -40,6 +40,7 @@ class AppLoaderDoc:
         self.data = None
         self.app_name = None
         self.classifier_mode = None
+        self.anonymize_snippets = None
         self.entity_classifier_obj = EntityClassifier()
 
     @staticmethod
@@ -202,7 +203,7 @@ class AppLoaderDoc:
                         entity_details,
                     ) = self.entity_classifier_obj.presidio_entity_classifier_and_anonymizer(
                         doc_info.data,
-                        anonymize_snippets=ClassifierConstants.anonymize_snippets.value,
+                        anonymize_snippets=self.anonymize_snippets,
                     )
                     doc_info.entities = entities
                     doc_info.entityDetails = entity_details
@@ -289,6 +290,13 @@ class AppLoaderDoc:
                 )
             else:
                 self.classifier_mode = self.data.get("classifier_mode")
+
+            if not data.get("anonymize_snippets"):
+                self.anonymize_snippets = config_details.get("classifier", {}).get(
+                    "anonymizeSnippets", False
+                )
+            else:
+                self.anonymize_snippets = data.get("anonymize_snippets")
 
             # create session
             self.db.create_session()

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -35,8 +35,8 @@ class AppLoaderDoc:
     def _initialize_data(self, data: dict):
         self.data = data
         self.app_name = data.get("name")
-        self._set_classifier_mode(data)
-        self._set_anonymize_snippets(data)
+        self._set_classifier_mode()
+        self._set_anonymize_snippets()
 
     def _write_pdf_report(self, final_report):
         """
@@ -125,29 +125,29 @@ class AppLoaderDoc:
                 loader_list.append(new_loader_data.model_dump())
                 app_details["loaders"] = loader_list
 
-    def _set_classifier_mode(self, data: dict):
+    def _set_classifier_mode(self):
         """
         This function defines the value of the classifier_mode: if it is included in the API request,
         it will be used; otherwise, the value will be taken from the config.
         """
-        if not data.get("classifier_mode"):
+        if not self.data.get("classifier_mode"):
             self.classifier_mode = config_details.get("classifier", {}).get(
                 "mode", ClassificationMode.ALL.value
             )
         else:
-            self.classifier_mode = data.get("classifier_mode")
+            self.classifier_mode = self.data.get("classifier_mode")
 
-    def _set_anonymize_snippets(self, data: dict):
+    def _set_anonymize_snippets(self):
         """
         This function defines the value of the anonymize_snippets: if it is included in the API request,
         it will be used; otherwise, the value will be taken from the config.
         """
-        if not data.get("anonymize_snippets"):
+        if not self.data.get("anonymize_snippets"):
             self.anonymize_snippets = config_details.get("classifier", {}).get(
                 "anonymizeSnippets", False
             )
         else:
-            self.anonymize_snippets = data.get("anonymize_snippets")
+            self.anonymize_snippets = self.data.get("anonymize_snippets")
 
     def process_request(self, data: dict):
         """

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -32,9 +32,11 @@ class AppLoaderDoc:
         self.classifier_mode = None
         self.anonymize_snippets = None
 
-    def _initialize_data(self, data):
+    def _initialize_data(self, data: dict):
         self.data = data
         self.app_name = data.get("name")
+        self._set_classifier_mode(data)
+        self._set_anonymize_snippets(data)
 
     def _write_pdf_report(self, final_report):
         """
@@ -123,9 +125,10 @@ class AppLoaderDoc:
                 loader_list.append(new_loader_data.model_dump())
                 app_details["loaders"] = loader_list
 
-    def process_request(self, data):
+    def _set_classifier_mode(self, data: dict):
         """
-        This process is entrypoint function for loader doc API implementation.
+        This function defines the value of the classifier_mode: if it is included in the API request,
+        it will be used; otherwise, the value will be taken from the config.
         """
         if not data.get("classifier_mode"):
             self.classifier_mode = config_details.get("classifier", {}).get(
@@ -134,6 +137,11 @@ class AppLoaderDoc:
         else:
             self.classifier_mode = data.get("classifier_mode")
 
+    def _set_anonymize_snippets(self, data: dict):
+        """
+        This function defines the value of the anonymize_snippets: if it is included in the API request,
+        it will be used; otherwise, the value will be taken from the config.
+        """
         if not data.get("anonymize_snippets"):
             self.anonymize_snippets = config_details.get("classifier", {}).get(
                 "anonymizeSnippets", False
@@ -141,6 +149,10 @@ class AppLoaderDoc:
         else:
             self.anonymize_snippets = data.get("anonymize_snippets")
 
+    def process_request(self, data: dict):
+        """
+        This process is entrypoint function for loader doc API implementation.
+        """
         self._initialize_data(data)
 
         try:

--- a/pebblo/app/service/service.py
+++ b/pebblo/app/service/service.py
@@ -30,6 +30,7 @@ class AppLoaderDoc:
         self.data = None
         self.app_name = None
         self.classifier_mode = None
+        self.anonymize_snippets = None
 
     def _initialize_data(self, data):
         self.data = data
@@ -133,6 +134,13 @@ class AppLoaderDoc:
         else:
             self.classifier_mode = data.get("classifier_mode")
 
+        if not data.get("anonymize_snippets"):
+            self.anonymize_snippets = config_details.get("classifier", {}).get(
+                "anonymizeSnippets", False
+            )
+        else:
+            self.anonymize_snippets = data.get("anonymize_snippets")
+
         self._initialize_data(data)
 
         try:
@@ -173,7 +181,11 @@ class AppLoaderDoc:
 
             # process input docs, app details, and generate final report
             loader_helper_obj = LoaderHelper(
-                app_details, self.data, load_id, self.classifier_mode
+                app_details,
+                self.data,
+                load_id,
+                self.classifier_mode,
+                self.anonymize_snippets,
             )
             (
                 app_details,

--- a/tests/app/service/test_doc_helper.py
+++ b/tests/app/service/test_doc_helper.py
@@ -1,0 +1,178 @@
+import datetime
+
+from pebblo.app.service.doc_helper import LoaderHelper
+
+app_details = {
+    "metadata": {
+        "createdAt": "2024-09-19 11:41:18.192182",
+        "modifiedAt": "2024-09-19 11:41:18.192183",
+    },
+    "name": "UnitTestApp",
+    "description": "Loader App using Pebblo",
+    "owner": "AppOwner",
+    "pluginVersion": "0.1.1",
+    "instanceDetails": {
+        "type": "desktop",
+        "host": "AppOwner-MBP",
+        "path": "/home/data/scripts",
+        "runtime": "Mac OSX",
+        "ip": "192.168.1.39",
+        "language": "python",
+        "languageVersion": "3.11.9",
+        "platform": "macOS-14.6.1-arm64-i386-64bit",
+        "os": "Darwin",
+        "osVersion": "Darwin Kernel Version 23.6.0: Mon Jul 29 21:13:04 PDT 2024; root:xnu-10063.141.2~1/RELEASE_ARM64_T6020",
+        "createdAt": "2024-09-19 11:41:18.192116",
+    },
+    "framework": {"name": "langchain", "version": "0.2.35"},
+    "lastUsed": "2024-09-19 11:41:18.192181",
+    "pebbloServerVersion": "0.1.19",
+    "pebbloClientVersion": "0.1.1",
+    "clientVersion": {"name": "langchain_community", "version": "0.2.12"},
+    "loaders": [
+        {
+            "name": "TextLoader",
+            "sourcePath": "/home/data/sample.txt",
+            "sourceType": "unsupported",
+            "sourceSize": 211,
+            "sourceFiles": [],
+            "lastModified": datetime.datetime.now(),
+        }
+    ],
+}
+
+classifier_response_input_doc = {
+    "doc": "Sachin's SSN is 222-85-4836. His passport ID is 5484880UA. His American express credit card number is\n371449635398431. AWS Access Key AKIAQIPT4PDORIRTV6PH. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+    "source_path": "/home/data/sens_data.csv",
+    "last_modified": datetime.datetime.now(),
+    "file_owner": "fileOwner",
+    "source_path_size": 211,
+}
+
+data = {
+    "name": "UnitTestApp",
+    "owner": "AppOwner",
+    "docs": [classifier_response_input_doc],
+    "plugin_version": "0.1.1",
+    "load_id": "26db970f-b4c6-44ae-9235-8f18236695a1",
+    "loader_details": {
+        "loader": "TextLoader",
+        "source_path": "/home/data/sample.txt",
+        "source_type": "unsupported",
+        "source_path_size": "211",
+        "source_aggregate_size": 211,
+    },
+    "loading_end": True,
+    "source_owner": "AppOwner",
+    "classifier_location": "local",
+    "classifier_mode": None,
+    "anonymize_snippets": None,
+}
+
+expected_output = {
+    "data": "Sachin's SSN is 222-85-4836. His passport ID is 5484880UA. His American express credit card number is\n371449635398431. AWS Access Key AKIAQIPT4PDORIRTV6PH. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+    "entityCount": 3,
+    "entities": {"us-ssn": 1, "credit-card-number": 1, "aws-access-key": 1},
+    "entityDetails": {
+        "us-ssn": [
+            {
+                "location": "16_27",
+                "confidence_score": "HIGH",
+                "entity_group": "pii-identification",
+            }
+        ],
+        "credit-card-number": [
+            {
+                "location": "102_117",
+                "confidence_score": "HIGH",
+                "entity_group": "pii-financial",
+            }
+        ],
+        "aws-access-key": [
+            {
+                "location": "134_154",
+                "confidence_score": "HIGH",
+                "entity_group": "secrets_and_tokens",
+            }
+        ],
+    },
+    "topicCount": 0,
+    "topics": {},
+    "topicDetails": {},
+}
+
+
+def test_get_classifier_response():
+    loader_helper = LoaderHelper(app_details, data=data, load_id=data.get("load_id"))
+    output = loader_helper._get_classifier_response(classifier_response_input_doc)
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_classifier_mode_entity():
+    loader_helper_classifier_mode_entity = LoaderHelper(
+        app_details, data=data, load_id=data.get("load_id"), classifier_mode="entity"
+    )
+    output = loader_helper_classifier_mode_entity._get_classifier_response(
+        classifier_response_input_doc
+    )
+
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_classifier_mode_topic():
+    loader_helper_classifier_mode_topic = LoaderHelper(
+        app_details, data=data, load_id=data.get("load_id"), classifier_mode="topic"
+    )
+    output = loader_helper_classifier_mode_topic._get_classifier_response(
+        classifier_response_input_doc
+    )
+
+    expected_output.update(
+        {
+            "entityCount": 0,
+            "entities": {},
+            "entityDetails": {},
+        }
+    )
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_anonymize_true():
+    loader_helper_anonymize_true = LoaderHelper(
+        app_details, data=data, load_id=data.get("load_id"), anonymize_snippets=True
+    )
+    output = loader_helper_anonymize_true._get_classifier_response(
+        classifier_response_input_doc
+    )
+
+    expected_output.update(
+        {
+            "data": "Sachin's SSN is &lt;US_SSN&gt;. His passport ID is 5484880UA. His American express credit card number is\n&lt;CREDIT_CARD&gt;. AWS Access Key &lt;AWS_ACCESS_KEY&gt;. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+            "entities": {"aws-access-key": 1, "credit-card-number": 1, "us-ssn": 1},
+            "entityCount": 3,
+            "entityDetails": {
+                "aws-access-key": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "secrets_and_tokens",
+                        "location": "141_163",
+                    }
+                ],
+                "credit-card-number": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "pii-financial",
+                        "location": "105_124",
+                    }
+                ],
+                "us-ssn": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "pii-identification",
+                        "location": "16_30",
+                    }
+                ],
+            },
+        }
+    )
+    assert output.model_dump() == expected_output

--- a/tests/app/service/test_loader_doc_service.py
+++ b/tests/app/service/test_loader_doc_service.py
@@ -1,0 +1,116 @@
+import datetime
+
+import pytest
+
+from pebblo.app.enums.common import ClassificationMode
+from pebblo.app.service.loader.loader_doc_service import AppLoaderDoc
+
+classifier_response_input_doc = {
+    "doc": "Sachin's SSN is 222-85-4836. His passport ID is 5484880UA. His American express credit card number is\n371449635398431. AWS Access Key AKIAQIPT4PDORIRTV6PH. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+    "source_path": "/home/data/sens_data.csv",
+    "last_modified": datetime.datetime.now(),
+    "file_owner": "fileOwner",
+    "source_path_size": 211,
+}
+
+expected_output = {
+    "data": "Sachin's SSN is 222-85-4836. His passport ID is 5484880UA. His American express credit card number is\n371449635398431. AWS Access Key AKIAQIPT4PDORIRTV6PH. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+    "entityCount": 3,
+    "entities": {"us-ssn": 1, "credit-card-number": 1, "aws-access-key": 1},
+    "entityDetails": {
+        "us-ssn": [
+            {
+                "location": "16_27",
+                "confidence_score": "HIGH",
+                "entity_group": "pii-identification",
+            }
+        ],
+        "credit-card-number": [
+            {
+                "location": "102_117",
+                "confidence_score": "HIGH",
+                "entity_group": "pii-financial",
+            }
+        ],
+        "aws-access-key": [
+            {
+                "location": "134_154",
+                "confidence_score": "HIGH",
+                "entity_group": "secrets_and_tokens",
+            }
+        ],
+    },
+    "topicCount": 0,
+    "topics": {},
+    "topicDetails": {},
+}
+
+
+@pytest.fixture
+def app_loader_helper():
+    return AppLoaderDoc()
+
+
+def test_get_classifier_response(app_loader_helper):
+    app_loader_helper.classifier_mode = ClassificationMode.ALL.value
+    app_loader_helper.anonymize_snippets = False
+    output = app_loader_helper._get_doc_classification(classifier_response_input_doc)
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_classifier_mode_entity(app_loader_helper):
+    app_loader_helper.classifier_mode = ClassificationMode.ENTITY.value
+    app_loader_helper.anonymize_snippets = False
+    output = app_loader_helper._get_doc_classification(classifier_response_input_doc)
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_classifier_mode_topic(app_loader_helper):
+    app_loader_helper.classifier_mode = ClassificationMode.TOPIC.value
+    app_loader_helper.anonymize_snippets = False
+    output = app_loader_helper._get_doc_classification(classifier_response_input_doc)
+    expected_output.update(
+        {
+            "entityCount": 0,
+            "entities": {},
+            "entityDetails": {},
+        }
+    )
+    assert output.model_dump() == expected_output
+
+
+def test_get_classifier_response_anonymize_true(app_loader_helper):
+    app_loader_helper.classifier_mode = ClassificationMode.ALL.value
+    app_loader_helper.anonymize_snippets = True
+    output = app_loader_helper._get_doc_classification(classifier_response_input_doc)
+    expected_output.update(
+        {
+            "data": "Sachin's SSN is &lt;US_SSN&gt;. His passport ID is 5484880UA. His American express credit card number is\n&lt;CREDIT_CARD&gt;. AWS Access Key &lt;AWS_ACCESS_KEY&gt;. client-secret is de1d4a2d-d9fa-44f1-84bb-4f73c004afda\n",
+            "entities": {"aws-access-key": 1, "credit-card-number": 1, "us-ssn": 1},
+            "entityCount": 3,
+            "entityDetails": {
+                "aws-access-key": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "secrets_and_tokens",
+                        "location": "141_163",
+                    }
+                ],
+                "credit-card-number": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "pii-financial",
+                        "location": "105_124",
+                    }
+                ],
+                "us-ssn": [
+                    {
+                        "confidence_score": "HIGH",
+                        "entity_group": "pii-identification",
+                        "location": "16_30",
+                    }
+                ],
+            },
+        }
+    )
+    assert output.model_dump() == expected_output


### PR DESCRIPTION
- Added `anonymize_snippets` as new field in `/loader/doc` API.
    - If `anonymize_snippets` is included in the API request, it will be used; otherwise, the value will be taken from config.
- Updated UTs
- Added type checking for previous code.
