### PR TITLE
Adding deprecation message for db storage type as file in config

### DIFF
--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -80,9 +80,8 @@ class StorageConfig(ConfigValidator):
 
     @staticmethod
     def validate_input(input_dict):
-        deprecate_error = (
-            "DeprecationWarning: 'file' in storage type is deprecated, use 'db' instead"
-        )
+        deprecate_error = f"DeprecationWarning: '{StorageTypes.FILE.value}' in storage type is deprecated, use '{StorageTypes.DATABASE.value}' instead"
+
         valid_storage_type = [storage_type.value for storage_type in StorageTypes]
         input_storage_type = input_dict.get("storage", {}).get("type")
         if input_storage_type not in valid_storage_type:

--- a/pebblo/app/config/config_validation.py
+++ b/pebblo/app/config/config_validation.py
@@ -78,6 +78,22 @@ class StorageConfig(ConfigValidator):
             if not os.path.exists(expand_path(str(default_location))):
                 os.makedirs(expand_path(str(default_location)), exist_ok=True)
 
+    @staticmethod
+    def validate_input(input_dict):
+        deprecate_error = (
+            "DeprecationWarning: 'file' in storage type is deprecated, use 'db' instead"
+        )
+        valid_storage_type = [storage_type.value for storage_type in StorageTypes]
+        input_storage_type = input_dict.get("storage", {}).get("type")
+        if input_storage_type not in valid_storage_type:
+            raise Exception(
+                f"Either '{StorageTypes.FILE.value}' or '{StorageTypes.DATABASE.value}' should be there in storage type"
+            )
+
+        if StorageTypes.FILE.value in input_storage_type:
+            print(deprecate_error)
+        return input_dict
+
 
 def expand_path(file_path: str) -> str:
     # Expand user (~) and environment variables
@@ -177,6 +193,7 @@ def validate_input(input_dict):
     """This function is used to validate input of config file"""
     validators = {
         "reports": ReportsConfig,
+        "storage": StorageConfig,
     }
 
     validation_errors = []

--- a/pebblo/app/enums/common.py
+++ b/pebblo/app/enums/common.py
@@ -8,7 +8,6 @@ class StorageTypes(Enum):
 
 class DBStorageTypes(Enum):
     SQLITE = "sqlite"
-    MONGODB = "mongodb"
 
 
 class ClassificationMode(Enum):

--- a/tests/app/config/test_config_validation.py
+++ b/tests/app/config/test_config_validation.py
@@ -8,6 +8,7 @@ from pebblo.app.config.config_validation import (
     DaemonConfig,
     LoggingConfig,
     ReportsConfig,
+    StorageConfig,
     validate_config,
 )
 
@@ -166,6 +167,45 @@ def test_classifier_config_validate():
     validator.validate()
     assert validator.errors == [
         "Error: Unsupported classifier mode 'Wrong' specified in the configuration. Valid values are ['all', 'entity', 'topic']"
+    ]
+
+
+def test_storage_config_validate():
+    # Test with storage type `file` correct value
+    storage = {"type": "file"}
+    validator = StorageConfig(storage)
+    validator.validate()
+    assert validator.errors == []
+
+    # Test with storage type `db` correct value
+    storage = {"type": "db", "db": "sqlite", "name": "pebblo_db"}
+    validator = StorageConfig(storage)
+    validator.validate()
+    assert validator.errors == []
+
+    # Test with wrong storage type
+    storage = {"type": "xyz"}
+    validator = StorageConfig(storage)
+    validator.validate()
+    assert validator.errors == [
+        "Error: Unsupported storage type 'xyz' specified in the configuration.Valid values are ['file', 'db']"
+    ]
+
+    # Test with storage type as `db` wrong `db` value
+    storage = {"type": "db", "db": "db123", "name": "pebblo_db"}
+    validator = StorageConfig(storage)
+    validator.validate()
+    assert validator.errors == [
+        "Error: Unsupported db type 'db123' specified in the configuration.Valid values are ['sqlite']"
+    ]
+
+    # Test with storage type as `db` without `db` and `name`
+    storage = {"type": "db"}
+    validator = StorageConfig(storage)
+    validator.validate()
+    assert validator.errors == [
+        "Error: Unsupported db type 'None' specified in the configuration.Valid values are ['sqlite']",
+        "Error: Unsupported db name 'None specified in the configurationString values are allowed only",
     ]
 
 


### PR DESCRIPTION
If in config file, storage type is set as file belo message will be shown while running pebblo server:

`DeprecationWarning: 'file' in storage type is deprecated, use 'db' instead`