### PR TITLE
Fix for data source name and size blank

### DIFF
--- a/pebblo/app/models/db_models.py
+++ b/pebblo/app/models/db_models.py
@@ -149,6 +149,7 @@ class AiDataSource(BaseModel):
     loadId: str
     metadata: Metadata
     sourcePath: str
+    sourceSize: int
     sourceType: str
     loader: str
 

--- a/pebblo/app/service/loader/loader_doc_service.py
+++ b/pebblo/app/service/loader/loader_doc_service.py
@@ -275,6 +275,7 @@ class AppLoaderDoc:
                 "modifiedAt": get_current_time(),
             },
             "sourcePath": loader_details.get("source_path"),
+            "sourceSize": loader_details.get("source_aggregate_size", 0),
             "sourceType": loader_details.get("source_type"),
             "loader": loader_details.get("loader"),
         }

--- a/pebblo/app/service/local_ui/loader_apps.py
+++ b/pebblo/app/service/local_ui/loader_apps.py
@@ -230,6 +230,7 @@ class LoaderApp:
                     "name": ds_data["loader"],
                     "sourcePath": ds_data["sourcePath"],
                     "sourceType": ds_data["sourceType"],
+                    "sourceSize": ds_data.get("sourceSize", "-"),
                     "findingsEntities": entity_count,
                     "findingsTopics": topic_count,
                     "totalSnippetCount": total_snippet_count,
@@ -245,6 +246,19 @@ class LoaderApp:
             self.loader_details["loader_data_source_count"] = len(
                 self.loader_details.get("loader_data_source_list", [])
             )
+
+    def _get_data_source_name(self, document_detail: dict):
+        """
+        Get data source name for given data source id from db.
+        """
+        data_source_id = document_detail.get("dataSourceId")
+        source_name = "-"
+        if data_source_id:
+            _, datasource = self.db.query(AiDataSourceTable, {"id": data_source_id})
+            if datasource:
+                source_name = datasource[0].data.get("loader", "-")
+
+        return source_name
 
     def _get_documents_with_findings(self, app_data: AiDataLoaderTable) -> None:
         """
@@ -268,9 +282,12 @@ class LoaderApp:
                 for topic, topic_data in document_detail.get("topics", {}).items():
                     topic_count += topic_data.get("count", 0)
 
+                source_name = self._get_data_source_name(document_detail)
+
                 if document_detail["sourcePath"] in loader_document_with_findings:
                     document_obj = {
                         "appName": document_detail["appName"],
+                        "sourceName":  source_name,
                         "owner": document_detail.get("owner", "-"),
                         "sourceSize": document_detail.get("sourceSize", 0),
                         "sourceFilePath": document_detail["sourcePath"],


### PR DESCRIPTION
- Fixed data source name missing on Dashboard => Safe Loader => Documents With Findings
Before:
<img width="1251" alt="Screenshot 2024-09-20 at 11 35 38 AM" src="https://github.com/user-attachments/assets/434d8c46-f94a-48b9-a50e-7975b12e8d3e">

After:
<img width="1232" alt="Screenshot 2024-09-20 at 11 35 16 AM" src="https://github.com/user-attachments/assets/0d763148-5f46-4eff-ba43-3fc69cbd5868">

- Fixed size empty issue on Dashboard => Safe Loader => Data Source
Before: blank(`-`) size
<img width="1227" alt="Screenshot 2024-09-20 at 12 28 43 PM" src="https://github.com/user-attachments/assets/fab5b47e-6b2d-4a5d-bc61-3411738d932d">


After:
<img width="1264" alt="Screenshot 2024-09-20 at 12 28 26 PM" src="https://github.com/user-attachments/assets/2e81bc9b-d539-4f08-8a41-65ce9771689c">
