### PR TITLE
Returning default value if no config path is passed

### DIFF
--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -22,11 +22,14 @@ def get_default_config_values():
     # set default config value
     conf_obj = Config(
         daemon=DaemonConfig(host="localhost", port=8000),
-        reports=ReportConfig(format="pdf", renderer="xhtml2pdf", cacheDir="~/.pebblo"),
-        logging=LoggingConfig(),
-        classifier=ClassifierConfig(
-            mode=ClassificationMode.ALL.value, anonymizeSnippets=False
+        reports=ReportConfig(
+            format="pdf",
+            renderer="xhtml2pdf",
+            cacheDir="~/.pebblo",
+            anonymizeSnippets=False,
         ),
+        logging=LoggingConfig(),
+        classifier=ClassifierConfig(mode=ClassificationMode.ALL.value),
         storage=StorageConfig(type="file", db=None),
         # for now, a default storage type is FILE, but in the next release DB will be the default storage type.
     )

--- a/pebblo/app/config/config.py
+++ b/pebblo/app/config/config.py
@@ -37,7 +37,7 @@ def load_config(path: Optional[str]) -> Tuple[dict, Config]:
     try:
         if not path:
             # If Path does not exist in command, set default config value
-            get_default_config_values()
+            return get_default_config_values()
 
         # If Path exist, set config value
         try:


### PR DESCRIPTION
While running pebblo server without config file, the default value was not getting returned with following error:

```
Error while loading config details, err: expected str, bytes or os.PathLike object, not NoneType
Exiting due to validation error...
```

Also, Added `anonymizeSnippets` in reports in default config