### PR TITLE
DB query optimization and reducing sqlalchemy logs

### DIFF
--- a/pebblo/app/models/sqltables.py
+++ b/pebblo/app/models/sqltables.py
@@ -1,3 +1,4 @@
+import logging
 from sqlalchemy import JSON, Column, Integer, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -5,6 +6,9 @@ from pebblo.app.config.config import var_server_config_dict
 from pebblo.app.enums.common import StorageTypes
 from pebblo.app.enums.enums import CacheDir, SQLiteTables
 from pebblo.app.utils.utils import get_full_path
+from pebblo.log import get_logger
+
+logger = get_logger(__name__)
 
 Base = declarative_base()
 
@@ -66,7 +70,10 @@ if storage_type == StorageTypes.DATABASE.value:
     # Create an engine that stores data in the local directory's my_database.db file.
     full_path = get_full_path(CacheDir.HOME_DIR.value)
     sqlite_db_path = CacheDir.SQLITE_ENGINE.value.format(full_path)
-    engine = create_engine(sqlite_db_path, echo=True)
+    if logger.isEnabledFor(logging.DEBUG):
+        engine = create_engine(sqlite_db_path, echo=True)
+    else:
+        engine = create_engine(sqlite_db_path)
 
     # Create all tables in the engine. This is equivalent to "Create Table" statements in raw SQL.
     Base.metadata.create_all(engine)

--- a/pebblo/app/models/sqltables.py
+++ b/pebblo/app/models/sqltables.py
@@ -1,4 +1,5 @@
 import logging
+
 from sqlalchemy import JSON, Column, Integer, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 

--- a/pebblo/app/models/sqltables.py
+++ b/pebblo/app/models/sqltables.py
@@ -1,7 +1,7 @@
 import logging
 
 from sqlalchemy import JSON, Column, Integer, create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from pebblo.app.config.config import var_server_config_dict
 from pebblo.app.enums.common import StorageTypes

--- a/pebblo/app/service/local_ui/loader_apps.py
+++ b/pebblo/app/service/local_ui/loader_apps.py
@@ -59,7 +59,11 @@ class LoaderApp:
         This function finds snippet details based on labels
         """
         response = []
-        result, output = self.db.query_by_list(AiSnippetsTable, "id", snippet_ids)
+        result, output = self.db.query_by_list(
+            AiSnippetsTable,
+            filter_key="id",
+            filter_values=snippet_ids[: ReportConstants.SNIPPET_LIMIT.value],
+        )
 
         if not result or len(output) == 0:
             return response

--- a/pebblo/app/service/local_ui/loader_apps.py
+++ b/pebblo/app/service/local_ui/loader_apps.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from fastapi import status
 from sqlalchemy.ext.declarative import declarative_base
-from pebblo.app.utils.utils import timeit
+
 from pebblo.app.enums.enums import CacheDir, ReportConstants
 from pebblo.app.models.db_models import (
     DataSource,
@@ -25,6 +25,7 @@ from pebblo.app.utils.utils import (
     get_current_time,
     get_full_path,
     get_pebblo_server_version,
+    timeit,
 )
 from pebblo.log import get_logger
 
@@ -60,12 +61,13 @@ class LoaderApp:
         response = []
         result, output = self.db.query_by_list(AiSnippetsTable, "id", snippet_ids)
 
+        if not result or len(output) == 0:
+            return response
+
         for row in output:
             if len(response) >= ReportConstants.SNIPPET_LIMIT.value:
                 break
 
-            if not result or len(output) == 0:
-                continue
             snippet_details = row.data
             entity_details = {}
             topic_details = {}

--- a/pebblo/app/service/local_ui/retriever_apps.py
+++ b/pebblo/app/service/local_ui/retriever_apps.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple
 
 from dateutil import parser
 from fastapi import status
-from pebblo.app.utils.utils import timeit
+
 from pebblo.app.config.config import var_server_config_dict
 from pebblo.app.models.db_response_models import (
     RetrievalAppDetails,
@@ -20,6 +20,7 @@ from pebblo.app.models.sqltables import (
     AiUser,
 )
 from pebblo.app.storage.sqlite_db import SQLiteClient
+from pebblo.app.utils.utils import timeit
 from pebblo.log import get_logger
 
 config_details = var_server_config_dict.get()

--- a/pebblo/app/service/local_ui/retriever_apps.py
+++ b/pebblo/app/service/local_ui/retriever_apps.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple
 
 from dateutil import parser
 from fastapi import status
-
+from pebblo.app.utils.utils import timeit
 from pebblo.app.config.config import var_server_config_dict
 from pebblo.app.models.db_response_models import (
     RetrievalAppDetails,
@@ -385,6 +385,7 @@ class RetrieverApp:
         )
         return json.dumps(response.model_dump(), default=str, indent=4)
 
+    @timeit
     def get_all_retriever_apps(self):
         try:
             self.db = SQLiteClient()
@@ -462,6 +463,7 @@ class RetrieverApp:
             # Closing the session
             self.db.session.close()
 
+    @timeit
     def get_retriever_app_details(self, app_name):
         try:
             retrieval_data = []

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -118,26 +118,27 @@ class SQLiteClient(Database):
         table_obj: Type[DeclarativeMeta],
         filter_key: str,
         filter_values: List[str],
-        max_filter_values: int = 100,
+        page_size: int = 100,
     ):
         """
         Pass filter like list. For example get snippets with ids in [<id1>, <id2>]
         :param table_obj: Table object on which query is to be performed
         :param filter_key: Search key
         :param filter_values: List of strings to be added to filter criteria.
-        :param max_filter_values: Max number ot items to be searched for. Default value is 100.
+        :param page_size: Page size to be used per iteration.
+                          All items from filter_values would be search based on page_size.
         """
         table_name = table_obj.__tablename__
-        logger.debug(f"Fetching data from table {table_name}")
-        total_records = len(filter_values)
-        total_pages = ceil(total_records / max_filter_values)
-        results = []
         try:
+            logger.debug(f"Fetching data from table {table_name}")
+            total_records = len(filter_values)
+            total_pages = ceil(total_records / page_size)
+            results = []
             for page in range(total_pages):
                 try:
                     # Calculate start and end indices for the current batch
-                    start_idx = page * max_filter_values
-                    end_idx = start_idx + max_filter_values
+                    start_idx = page * page_size
+                    end_idx = start_idx + page_size
 
                     # Slice filter_values to match the current batch
                     current_batch = filter_values[start_idx:end_idx]
@@ -159,6 +160,7 @@ class SQLiteClient(Database):
                     logger.error(
                         f"Failed in fetching data from table {table_name}, Error: {err}"
                     )
+                    continue
 
             return True, results
 

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -1,8 +1,10 @@
 import logging
+from typing import List, Type
 
 from sqlalchemy import and_, create_engine, func, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
+from sqlalchemy.orm.decl_api import DeclarativeMeta
 
 from pebblo.app.enums.enums import CacheDir
 from pebblo.app.storage.database import Database
@@ -110,17 +112,28 @@ class SQLiteClient(Database):
             return False, err
 
     @timeit
-    def query_by_list(self, table_obj, key, ids):
+    def query_by_list(
+        self,
+        table_obj: Type[DeclarativeMeta],
+        filter_key: str,
+        filter_values: List[str],
+    ):
         """
         Pass filter like list. For example get snippets with ids in [<id1>, <id2>]
+        :param table_obj: Table object on which query is to be performed
+        :param filter_key: Search key
+        :param filter_values: List of strings to be added to filter criteria
         """
-        # This function is not in use right now, But in the local_ui it will get used.
         table_name = table_obj.__tablename__
         try:
             logger.debug(f"Fetching data from table {table_name}")
             output = (
                 self.session.query(table_obj)
-                .filter(func.json_extract(table_obj.data, f"$.{key}").in_(ids))
+                .filter(
+                    func.json_extract(table_obj.data, f"$.{filter_key}").in_(
+                        filter_values
+                    )
+                )
                 .all()
             )
             return True, output

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -1,6 +1,6 @@
 import logging
-from typing import List, Type
 from math import ceil
+from typing import List, Type
 
 from sqlalchemy import and_, create_engine, func, text
 from sqlalchemy.orm import sessionmaker
@@ -143,7 +143,9 @@ class SQLiteClient(Database):
                     # Slice filter_values to match the current batch
                     current_batch = filter_values[start_idx:end_idx]
 
-                    logger.debug(f"Processing batch {page + 1}/{total_pages}, filter values: {current_batch}")
+                    logger.debug(
+                        f"Processing batch {page + 1}/{total_pages}, filter values: {current_batch}"
+                    )
 
                     # Execute the query for the current batch
                     batch_result = (

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -141,7 +141,7 @@ class SQLiteClient(Database):
             logger.error(
                 f"Failed in fetching data from table {table_name}, Error: {err}"
             )
-            return False, err
+            return False, []
 
     @timeit
     def update_data(self, table_obj, data):

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -1,5 +1,6 @@
 import logging
-from sqlalchemy import and_, create_engine, text, func
+
+from sqlalchemy import and_, create_engine, func, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -108,7 +109,6 @@ class SQLiteClient(Database):
             )
             return False, err
 
-
     @timeit
     def query_by_list(self, table_obj, key, ids):
         """
@@ -118,9 +118,11 @@ class SQLiteClient(Database):
         table_name = table_obj.__tablename__
         try:
             logger.debug(f"Fetching data from table {table_name}")
-            output = self.session.query(table_obj).filter(
-                func.json_extract(table_obj.data, f"$.{key}").in_(ids)
-            ).all()
+            output = (
+                self.session.query(table_obj)
+                .filter(func.json_extract(table_obj.data, f"$.{key}").in_(ids))
+                .all()
+            )
             return True, output
         except Exception as err:
             logger.error(

--- a/pebblo/app/storage/sqlite_db.py
+++ b/pebblo/app/storage/sqlite_db.py
@@ -117,16 +117,20 @@ class SQLiteClient(Database):
         table_obj: Type[DeclarativeMeta],
         filter_key: str,
         filter_values: List[str],
+        max_filter_values: int = 100,
     ):
         """
         Pass filter like list. For example get snippets with ids in [<id1>, <id2>]
         :param table_obj: Table object on which query is to be performed
         :param filter_key: Search key
-        :param filter_values: List of strings to be added to filter criteria
+        :param filter_values: List of strings to be added to filter criteria.
+        :param max_filter_values: Max number ot items to be searched for. Default value is 10.
         """
         table_name = table_obj.__tablename__
         try:
             logger.debug(f"Fetching data from table {table_name}")
+            # limit the number of values being passed for search query to avoid usage of long list.
+            filter_values = filter_values[:max_filter_values]
             output = (
                 self.session.query(table_obj)
                 .filter(

--- a/tests/app/storage/test_sqlite_db.py
+++ b/tests/app/storage/test_sqlite_db.py
@@ -3,10 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy.orm import Session
 
-from pebblo.app.models.sqltables import (
-    AiDataSourceTable,
-    AiSnippetsTable,
-)
+from pebblo.app.models.sqltables import AiSnippetsTable
 
 # Assume table_obj is imported from the actual module where the table is defined
 

--- a/tests/app/storage/test_sqlite_db.py
+++ b/tests/app/storage/test_sqlite_db.py
@@ -49,7 +49,13 @@ def test_query_by_list_page_size(sqlite_client):
     mock_session = sqlite_client.session
     table_obj = AiSnippetsTable
     filter_key = "id"
-    filter_values = ["snippet_id1", "snippet_id2", "snippet_id3", "snippet_id4", "snippet_id5"]
+    filter_values = [
+        "snippet_id1",
+        "snippet_id2",
+        "snippet_id3",
+        "snippet_id4",
+        "snippet_id5",
+    ]
     page_size = 2
 
     # Mocking query result
@@ -57,7 +63,11 @@ def test_query_by_list_page_size(sqlite_client):
     mock_result_page_2 = ["result3", "result4"]
     mock_result_page_3 = ["result5"]
     mock_query = mock_session.query().filter().all
-    mock_query.side_effect = [mock_result_page_1, mock_result_page_2, mock_result_page_3]
+    mock_query.side_effect = [
+        mock_result_page_1,
+        mock_result_page_2,
+        mock_result_page_3,
+    ]
 
     # Call the method
     success, result = sqlite_client.query_by_list(
@@ -66,13 +76,7 @@ def test_query_by_list_page_size(sqlite_client):
 
     # Assertions
     assert success is True
-    assert result == [
-        "result1",
-        "result2",
-        "result3",
-        "result4",
-        "result5"
-    ]
+    assert result == ["result1", "result2", "result3", "result4", "result5"]
 
 
 def test_query_by_list_failure(sqlite_client):
@@ -89,7 +93,7 @@ def test_query_by_list_failure(sqlite_client):
         table_obj=mock_table_obj,
         filter_key=filter_key,
         filter_values=filter_values,
-        page_size=page_size
+        page_size=page_size,
     )
 
     assert success is False

--- a/tests/app/storage/test_sqlite_db.py
+++ b/tests/app/storage/test_sqlite_db.py
@@ -33,70 +33,65 @@ def test_query_by_list_success(sqlite_client, mocker):
     mock_filter = mock_query.filter.return_value
     mock_filter.all.return_value = ["result1", "result2"]  # Mocked results
 
-    # Mock func.json_extract
-    mock_json_extract = mocker.patch("sqlalchemy.sql.func.json_extract")
-
     # Call the method
     success, result = sqlite_client.query_by_list(table_obj, filter_key, filter_values)
-
-    # Ensure that `json_extract` was called with the correct arguments
-    mock_json_extract.assert_called_once_with(table_obj.data, f"$.{filter_key}")
 
     # Assertions
     assert success is True
     assert result == ["result1", "result2"]
 
+    # Ensure the query was called only once (no pagination)
+    assert mock_session.query().filter().all.call_count == 1
 
-def test_query_by_list_max_filter_values(sqlite_client, mocker):
+
+def test_query_by_list_page_size(sqlite_client):
     """Test successful query with query_by_list to verify max_filter_limit"""
     mock_session = sqlite_client.session
     table_obj = AiSnippetsTable
     filter_key = "id"
-    filter_values = ["snippet_id1", "snippet_id2", "snippet_id3", "snippet_id4"]
-    max_filter_values = 2
+    filter_values = ["snippet_id1", "snippet_id2", "snippet_id3", "snippet_id4", "snippet_id5"]
+    page_size = 2
 
     # Mocking query result
-    mock_query = mock_session.query.return_value
-    mock_filter = mock_query.filter.return_value
-    mock_filter.all.return_value = ["result1", "result2"]  # Mocked results
-
-    # Mock func.json_extract
-    mock_json_extract = mocker.patch("sqlalchemy.sql.func.json_extract")
+    mock_result_page_1 = ["result1", "result2"]
+    mock_result_page_2 = ["result3", "result4"]
+    mock_result_page_3 = ["result5"]
+    mock_query = mock_session.query().filter().all
+    mock_query.side_effect = [mock_result_page_1, mock_result_page_2, mock_result_page_3]
 
     # Call the method
     success, result = sqlite_client.query_by_list(
-        table_obj, filter_key, filter_values, max_filter_values
+        table_obj, filter_key, filter_values, page_size
     )
-
-    # Ensure that `json_extract` was called with the correct arguments
-    mock_json_extract.assert_called_once_with(table_obj.data, f"$.{filter_key}")
 
     # Assertions
     assert success is True
     assert result == [
         "result1",
         "result2",
-    ]  # this should only limit first two items and skip rest two in the input.
+        "result3",
+        "result4",
+        "result5"
+    ]
 
 
-def test_query_by_list_failure(sqlite_client, mocker):
-    """Test query_by_list failure due to an exception."""
+def test_query_by_list_failure(sqlite_client):
     mock_session = sqlite_client.session
-    mock_table_obj = AiDataSourceTable
-    filter_key = "invalid_key"
+    mock_table_obj = AiSnippetsTable
+    filter_key = "id"
     filter_values = ["value1", "value2"]
 
-    # Mocking an exception when calling the query
-    mock_session.query.side_effect = Exception(
-        "DB Error. Key with name 'invalid_key' does not exists."
+    # Create mock data
+    page_size = "abcd"  # invalid page size
+
+    # Call the query_by_list function
+    success, results = sqlite_client.query_by_list(
+        table_obj=mock_table_obj,
+        filter_key=filter_key,
+        filter_values=filter_values,
+        page_size=page_size
     )
 
-    # Call the method
-    success, result = sqlite_client.query_by_list(
-        mock_table_obj, filter_key, filter_values
-    )
-
-    # Assertions
     assert success is False
-    assert result == []
-    mock_session.query.assert_called_once_with(mock_table_obj)
+    assert results == []
+    mock_session.query.assert_not_called()

--- a/tests/app/test_storage.py
+++ b/tests/app/test_storage.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+from sqlalchemy.ext.declarative import DeclarativeMeta
+from sqlalchemy.sql import func
+from pebblo.app.models.sqltables import (
+    AiSnippetsTable,
+)
+
+# Assume table_obj is imported from the actual module where the table is defined
+
+
+class MockTable(DeclarativeMeta):
+    __tablename__ = 'mock_table'
+    data = {}
+
+
+@pytest.fixture
+def sqlite_client():
+    """Fixture for creating an SQLiteClient instance."""
+    from pebblo.app.storage.sqlite_db import SQLiteClient
+    client = SQLiteClient()
+    client.session = MagicMock(spec=Session)
+    return client
+
+
+def test_query_by_list_success(sqlite_client, mocker):
+    """Test successful query with query_by_list."""
+    mock_session = sqlite_client.session
+    table_obj = AiSnippetsTable
+    filter_key = "id"
+    filter_values = ["snippet_id1", "snippet_id2"]
+
+    # Mocking query result
+    mock_query = mock_session.query.return_value
+    mock_filter = mock_query.filter.return_value
+    mock_filter.all.return_value = ["result1", "result2"]  # Mocked results
+
+    # Mock func.json_extract
+    mock_json_extract = mocker.patch('sqlalchemy.sql.func.json_extract')
+
+    # Call the method
+    success, result = sqlite_client.query_by_list(table_obj, filter_key, filter_values)
+
+    # Ensure that `json_extract` was called with the correct arguments
+    mock_json_extract.assert_called_once_with(table_obj.data, f"$.{filter_key}")
+
+    # Assertions
+    assert success is True
+    assert result == ["result1", "result2"]
+
+
+def test_query_by_list_failure(sqlite_client, mocker):
+    """Test query_by_list failure due to an exception."""
+    mock_session = sqlite_client.session
+    mock_table_obj = MockTable  # Use your actual table object here
+    filter_key = "invalid_key"
+    filter_values = ["value1", "value2"]
+
+    # Mocking an exception when calling the query
+    mock_session.query.side_effect = Exception("DB Error. Key with name 'invalid_key' does not exists.")
+
+    # Call the method
+    success, result = sqlite_client.query_by_list(mock_table_obj, filter_key, filter_values)
+
+    # Assertions
+    assert success is False
+    assert result == []
+    mock_session.query.assert_called_once_with(mock_table_obj)
+


### PR DESCRIPTION
This includes two fixes:

1. Query optimization, in order to reduce the execution time for loading UI.
2. Moved sqlalchemy logging only when logging level is set to debug. See logs below.
3. Added `timeit` function for 4 entry point UI functions. This can be used to see how long did it take for backend processing for data generating for dashboard(loader and retriever), app details page(loader and retriever). Time tracking would be done only when logging level is debug.
4. Fixed import warning.

Query Optimisation Results:
Here’s a table comparing the execution times before and after:

| **Function Name**                | **Execution Time (Before)**  | **Execution Time (After)**   |
|-----------------------------------|------------------------------|------------------------------|
| get_all_loader_apps               | 6.1778 seconds               | 1.0898 seconds               |
| get_all_retriever_apps            | 0.1952 seconds               | 0.0177 seconds               |
| get_loader_app_details            | 2.8017 seconds               | 0.2574 seconds               |
| get_retriever_app_details         | 0.0142 seconds               | 0.0140 seconds               |


**SQLAlchemy logging improvement:**
**With logging level info:**

```
(venv-3-11) ➜  pebblo git:(shreyas-db-query-optimization) ✗ pebblo
DeprecationWarning: 'file' in storage type is deprecated, use 'db' instead
Pebblo server version 0.1.19 starting ...
Downloading topic, entity classifier models ...
Initializing topic classifier ...
 30%|██████████████████████████████████████████████████▍                                                                                                                     | 3/10 [00:02<00:05,  1.35it/s]/Users/shreyasdamle/work/cloud_defense/pebblo/venv-3-11/lib/python3.11/site-packages/huggingface_hub/file_download.py:1142: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Initializing topic classifier ... done
Initializing entity classifier ...
Initializing entity classifier ... done
 70%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                                  | 7/10 [00:04<00:01,  1.59it/s]Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:06<00:00,  1.53it/s]
2024-09-26 17:22:24.932 - pebblo.app.config.service - INFO - Starting Pebblo Server with config {'daemon': {'host': 'localhost', 'port': 8000}, 'reports': {'format': 'pdf', 'renderer': 'xhtml2pdf', 'cacheDir': '~/.pebblo', 'anonymizeSnippets': False}, 'classifier': {'mode': 'all', 'anonymizeSnippets': None}, 'logging': {'level': 'INFO', 'file': '/tmp/logs/pebblo.log', 'maxFileSize': 8388608, 'backupCount': 3}, 'storage': {'type': 'file', 'db': None, 'location': '/Users/shreyasdamle/work/cloud_defense/shreyas-damle/pebblo', 'name': 'pebblo'}}
2024-09-26 17:22:24,945 - uvicorn.error - INFO - Started server process [85821]
2024-09-26 17:22:24,945 - uvicorn.error - INFO - Waiting for application startup.
2024-09-26 17:22:24,945 - uvicorn.error - INFO - Application startup complete.
2024-09-26 17:22:24,950 - uvicorn.error - INFO - Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
```

**With logging level as debug:**
```
(venv-3-11) ➜  pebblo git:(shreyas-db-query-optimization) ✗ pebblo --config pebblo/app/config/config.yaml
Pebblo server version 0.1.19 starting ...
Downloading topic, entity classifier models ...
Initializing topic classifier ...
 30%|██████████████████████████████████████████████████▍                                                                                                                     | 3/10 [00:02<00:04,  1.50it/s]/Users/shreyasdamle/work/cloud_defense/pebblo/venv-3-11/lib/python3.11/site-packages/huggingface_hub/file_download.py:1142: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Initializing topic classifier ... done
Initializing entity classifier ...
Initializing entity classifier ... done
 70%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▌                                                  | 7/10 [00:04<00:01,  1.67it/s]2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine BEGIN (implicit)
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aiapp")
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aidataloader")
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("airetrieval")
2024-09-26 17:23:39,904 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aidatasource")
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aidocument")
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aisnippets")
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine PRAGMA main.table_info("aiuser")
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine [raw sql] ()
2024-09-26 17:23:39,905 INFO sqlalchemy.engine.Engine COMMIT
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
Some weights of the model checkpoint at daxa-ai/pebblo-classifier were not used when initializing DistilBertForSequenceClassification: ['classifier.lora_A.default.weight', 'classifier.lora_B.default.weight', 'pre_classifier.lora_A.default.weight', 'pre_classifier.lora_B.default.weight']
- This IS expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing DistilBertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:06<00:00,  1.55it/s]
2024-09-26 17:23:41.844 - pebblo.app.config.service - INFO - Starting Pebblo Server with config {'daemon': {'host': 'localhost', 'port': 8000}, 'reports': {'format': 'pdf', 'renderer': 'xhtml2pdf', 'cacheDir': '~/.pebblo', 'anonymizeSnippets': False}, 'classifier': {'mode': 'all', 'anonymizeSnippets': None}, 'logging': {'level': 'DEBUG', 'file': '/tmp/logs/pebblo.log', 'maxFileSize': 8388608, 'backupCount': 3}, 'storage': {'type': 'db', 'db': 'sqlite', 'location': '/Users/shreyasdamle/work/cloud_defense/shreyas-damle/pebblo', 'name': 'pebblo'}}
2024-09-26 17:23:41,856 - uvicorn.error - INFO - Started server process [85955]
2024-09-26 17:23:41,856 - uvicorn.error - INFO - Waiting for application startup.
2024-09-26 17:23:41,856 - uvicorn.error - INFO - Application startup complete.
2024-09-26 17:23:41,858 - uvicorn.error - INFO - Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
```


**Fixed import warning while running UTs:**
```
pebblo/app/models/sqltables.py:14
  /Users/shreyasdamle/work/cloud_defense/shreyas-damle/pebblo/pebblo/app/models/sqltables.py:14: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()
```