### PR TITLE
Updated config file for docker.

### DIFF
--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -7,5 +7,8 @@ reports:
   format: pdf
   renderer: weasyprint
   cacheDir: /opt/.pebblo
-classifier:
   anonymizeSnippets: False
+classifier:
+  mode: all
+storage:
+  type: file

--- a/docs/gh_pages/docs/config.md
+++ b/docs/gh_pages/docs/config.md
@@ -59,8 +59,9 @@ reports:
   format: pdf
   renderer: xhtml2pdf
   outputDir: ~/.pebblo
-classifier:
   anonymizeSnippets: False
+classifier:
+  mode: all
 storage:
   type: file
 ```

--- a/docs/gh_pages/docs/config.md
+++ b/docs/gh_pages/docs/config.md
@@ -58,7 +58,7 @@ logging:
 reports:
   format: pdf
   renderer: xhtml2pdf
-  outputDir: ~/.pebblo
+  cacheDir: ~/.pebblo
   anonymizeSnippets: False
 classifier:
   mode: all


### PR DESCRIPTION
We are getting below warning with Pebblo:0.1.20 docker image
`DeprecationWarning: 'anonymizeSnippets' in classifier is deprecated, use 'anonymizeSnippets' in reports instead`.

With this code change, updated the config file.

Tested locally by building image.