### PR TITLE
Downgraded version of twine to 6.0.1

### DIFF
--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload to Test PyPI
         run: |
-          pip install twine
+          pip install twine==6.0.1
           twine upload --repository-url https://test.pypi.org/legacy/ dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Downgraded version of twine to 6.0.1 for resolving release issue to test pypi

https://github.com/pypi/warehouse/issues/15611#issuecomment-2608722983

