### PR TITLE
Downgraded Twine Version for pypi release

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload to PyPI
         run: |
-          pip install twine
+          pip install twine==6.0.1
           twine upload dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Downgraded Twine Version to 6.0.1 for Pypi release. Since there was no version given in pypi_release.yaml it was installing Twine's latest version, and the workflow was breaking because of that.